### PR TITLE
masscopy - remove interview

### DIFF
--- a/masscopy.py
+++ b/masscopy.py
@@ -42,18 +42,6 @@ def main():
             if os.path.isfile(manifest):
                 dirlist.append(os.path.join(args.input, source_directory))
     all_files = dirlist
-    if not permission == 'y' or permission == 'Y':
-        print '\n\n**** All of these folders will be copied to %s\n' % args.o
-        for i in all_files:
-            print i
-        permission =  raw_input('\n**** These are the directories that will be copied. \n**** If this looks ok, please press Y, otherwise, type N\n' )
-        while permission not in ('Y','y','N','n'):
-            permission =  raw_input('\n**** These are the directories that will be copied. \n**** If this looks ok, please press Y, otherwise, type N\n')
-        if permission == 'n' or permission == 'N':
-            print 'Exiting at your command- Cheerio for now'
-            sys.exit()
-        elif permission =='y' or permission == 'Y':
-            print 'Ok so!'
     processed_dirs = []
     log_names = []
     for i in all_files:

--- a/masscopy.py
+++ b/masscopy.py
@@ -31,7 +31,6 @@ def main():
                     help='full path of output directory', required=True)
     args = parser.parse_args()
     dirlist = []
-    permission = ''
     for source_directory in os.listdir(args.input):
         if os.path.isdir(
             os.path.join(args.input,source_directory)
@@ -44,6 +43,9 @@ def main():
     all_files = dirlist
     processed_dirs = []
     log_names = []
+    print '\n\n**** All of these folders will be copied to %s\n' % args.o
+    for i in all_files:
+        print i
     for i in all_files:
         if os.path.isdir(
             os.path.join(args.o, os.path.basename(i))

--- a/testfiles.py
+++ b/testfiles.py
@@ -1,33 +1,9 @@
 #!/usr/bin/env python
 import sys
 import subprocess
-import os
 
+input_dir = sys.argv[1]
 
-def main():
-    '''
-    Creates three v210/mov tesfiles in a test_files subdirectory
-    '''
-    output_dir = os.path.join(sys.argv[1], 'test_files')
-    bars_cmd = [
-        'ffmpeg', '-f', 'lavfi', '-i', 'testsrc',
-        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'bars.mov')
-        ]
-    mandel_cmd = [
-        'ffmpeg', '-f', 'lavfi', '-i', 'mandelbrot',
-        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'mandel.mov')
-        ]
-    life_cmd = [
-        'ffmpeg', '-f', 'lavfi', '-i', 'life',
-        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'life.mov')
-        ]
-    if not os.path.isdir(output_dir):
-        os.makedirs(output_dir)
-    subprocess.call(bars_cmd)
-    subprocess.call(mandel_cmd)
-    subprocess.call(life_cmd)
-
-if __name__ == '__main__':
-    main()
-
-
+subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'testsrc', '-c:v', 'prores', '-t', '20', input_dir + 'bars.mov'])
+subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'mandelbrot', '-c:v', 'prores', '-t', '20', input_dir + 'mandel.mov'])
+subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'life', '-c:v', 'prores', '-t', '20', input_dir + 'life.mov'])

--- a/testfiles.py
+++ b/testfiles.py
@@ -1,9 +1,33 @@
 #!/usr/bin/env python
 import sys
 import subprocess
+import os
 
-input_dir = sys.argv[1]
 
-subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'testsrc', '-c:v', 'prores', '-t', '20', input_dir + 'bars.mov'])
-subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'mandelbrot', '-c:v', 'prores', '-t', '20', input_dir + 'mandel.mov'])
-subprocess.call(['ffmpeg', '-f', 'lavfi', '-i', 'life', '-c:v', 'prores', '-t', '20', input_dir + 'life.mov'])
+def main():
+    '''
+    Creates three v210/mov tesfiles in a test_files subdirectory
+    '''
+    output_dir = os.path.join(sys.argv[1], 'test_files')
+    bars_cmd = [
+        'ffmpeg', '-f', 'lavfi', '-i', 'testsrc',
+        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'bars.mov')
+        ]
+    mandel_cmd = [
+        'ffmpeg', '-f', 'lavfi', '-i', 'mandelbrot',
+        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'mandel.mov')
+        ]
+    life_cmd = [
+        'ffmpeg', '-f', 'lavfi', '-i', 'life',
+        '-c:v', 'v210', '-t', '20', os.path.join(output_dir, 'life.mov')
+        ]
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
+    subprocess.call(bars_cmd)
+    subprocess.call(mandel_cmd)
+    subprocess.call(life_cmd)
+
+if __name__ == '__main__':
+    main()
+
+


### PR DESCRIPTION
Hi @raecasey  @aoifefitz2016 - this removes the interview from the start of masscopy - which I originally added as a method to test out the script. I don't think that it's needed as masscopy is pretty careful about what it copies, and the script still prints which directories are to be copied and where.

The main benefit of this is that it allows loopline.py and masscopy to be linked with `&&`, so at the end of the day, you can run both scripts one after the other, eg
`loopline.py /home/kieranjol/fake_capture_folder && masscopy.py /home/kieranjol/fake_capture_folder -o /home/kieranjol/4tb_backup
`
You'd very much need to check that CSV file in the source media directory that tells you if makeffv1 was lossless or not as that message gets a bit buried now.

lemme know if ye think this is an improvement and should be merged. I think it'd make things much more productive anyhow.