### PR TITLE
masscopy/moveit - add lto/gcp options

### DIFF
--- a/masscopy.py
+++ b/masscopy.py
@@ -29,6 +29,8 @@ def main():
     parser.add_argument(
                     '-o',
                     help='full path of output directory', required=True)
+    parser.add_argument(
+                    '-l', '-lto', action='store_true', help='use gcp instead of rsync on osx for SPEED on LTO')
     args = parser.parse_args()
     dirlist = []
     permission = ''
@@ -69,10 +71,16 @@ def main():
                 ) + time.strftime("_%Y_%m_%dT%H_%M_%S")
             desktop_logs_dir = make_desktop_logs_dir()
             log_name_source = "%s/%s.log" % (desktop_logs_dir, log_name_source_)
-            moveit_cmd = [
-                sys.executable,
-                os.path.expanduser("~/ifigit/ifiscripts/moveit.py"),
-                os.path.join(args.input,i), args.o]
+            if args.l:
+                moveit_cmd = [
+                    sys.executable,
+                    os.path.expanduser("~/ifigit/ifiscripts/moveit.py"),'-l',
+                    os.path.join(args.input,i), args.o]
+            else:
+                moveit_cmd = [
+                    sys.executable,
+                    os.path.expanduser("~/ifigit/ifiscripts/moveit.py"),
+                    os.path.join(args.input,i), args.o]
             subprocess.check_call(moveit_cmd)
             processed_dirs.append(os.path.basename(os.path.join(args.input,i)))
             log_names.append(log_name_source)

--- a/moveit.py
+++ b/moveit.py
@@ -114,16 +114,21 @@ def copy_dir():
         subprocess.call(['robocopy',source, destination_final_path, '/E', '/XA:SH', '/XD', '.*', '/XD', '*System Volume Information*', '/XD', '$Recycle.bin', '/a-:SH', '/a+:R'])
         generate_log(log_name_source, 'EVENT = File Transfer - Windows O.S - Software=Robocopy')
     elif _platform == "darwin":
+        if args.l:
+           cmd = [ 'gcp','--preserve=mode,timestamps', '-nRv', source, destination_final_path]
+           generate_log(log_name_source, 'EVENT = File Transfer - OSX - Software=gcp')
+           subprocess.call(cmd) 
         # https://github.com/amiaopensource/ltopers/blob/master/writelto#L51
-        if rootpos == 'y':
-            if not os.path.isdir(destination + '/' + dirname):
-                os.makedirs(destination + '/' + dirname)
-            cmd = ['rsync','-rtv', '--exclude=.*', '--exclude=.*/', '--stats','--progress', source, destination + '/' + dirname]
         else:
-            cmd = ['rsync','-rtv', '--exclude=.*', '--exclude=.*/', '--stats','--progress', source, destination]
-        generate_log(log_name_source, 'EVENT = File Transfer - OSX - Software=rsync')
-        print cmd
-        subprocess.call(cmd)
+            if rootpos == 'y':
+                if not os.path.isdir(destination + '/' + dirname):
+                    os.makedirs(destination + '/' + dirname)
+                cmd = ['rsync','-rtv', '--exclude=.*', '--exclude=.*/', '--stats','--progress', source, destination + '/' + dirname]
+            else:
+                cmd = ['rsync','-rtv', '--exclude=.*', '--exclude=.*/', '--stats','--progress', source, destination]
+            generate_log(log_name_source, 'EVENT = File Transfer - OSX - Software=rsync')
+            print cmd
+            subprocess.call(cmd)
     elif _platform == "linux2":
         # https://github.com/amiaopensource/ltopers/blob/master/writelto#L51
         cmd = [ 'cp','--preserve=mode,timestamps', '-nRv',source, destination_final_path]
@@ -201,6 +206,7 @@ parser = argparse.ArgumentParser(description='Copy directory with checksum compa
 parser.add_argument('source', help='Input directory')
 parser.add_argument('destination', help='Destination directory')
 parser.add_argument('-b', '-benchmark', action='store_true', help='display benchmark')
+parser.add_argument('-l', '-lto', action='store_true', help='use gcp instead of rsync on osx for SPEED on LTO')
 #parser.add_argument('-sha', '-sha512', action='store_true', help='use sha512 instead of md5')
 
 global rootpos


### PR DESCRIPTION
I tested this out on an LTO move and it worked fine.
here was my command:
`masscopy.py /Volumes/ifi_loopline_a1/loopline_ffv1 -l -o /Volumes/ltfs0`
It means that you can add a `-lto` or `-l` to your masscopy or moveit command line and ONLY on OSX, it will use gcp instead of rsync, resulting in far greater speed.
@raecasey