### PR TITLE
ififuncs/moveit moves desktop manifests to subfolder

### DIFF
--- a/ififuncs.py
+++ b/ififuncs.py
@@ -288,6 +288,9 @@ def make_desktop_manifest_dir():
     if not os.path.isdir(desktop_manifest_dir):
         #I should probably ask permission here, or ask for alternative location
         os.makedirs(desktop_manifest_dir)
+    else:
+        if not os.path.isdir(os.path.join(desktop_manifest_dir, 'old_manifests')):
+            os.makedirs(os.path.join(desktop_manifest_dir, 'old_manifests'))
     return desktop_manifest_dir
 
 

--- a/moveit.py
+++ b/moveit.py
@@ -10,6 +10,7 @@ import time
 import argparse
 import getpass
 import hashlib
+import shutil
 from sys import platform as _platform
 from ififuncs import make_desktop_logs_dir, make_desktop_manifest_dir, generate_log
 
@@ -367,6 +368,9 @@ else:
         generate_log(log_name_source, 'EVENT = File Transfer Failure Explanation -  %s files in your destination,  %s files at source' % (destination_count, source_count))
     else:
         print ' %s files in your destination \n %s files at source' % (destination_count, source_count)
-
+manifest_rename = manifest[:-4] + time.strftime("_%Y_%m_%dT%H_%M_%S") + '.md5'
+if os.path.dirname(manifest) == desktop_manifest_dir:
+    os.rename(manifest, manifest_rename)
+    shutil.move(manifest_rename, os.path.join(desktop_manifest_dir, 'old_manifests' ))
 if args.b:
     display_benchmark()


### PR DESCRIPTION
This will 
* Create an `old_manifests` subfolder in the desktop `moveit_manifests` folder.
* Only if the source manifest  is stored on the desktop will the manifest be renamed with the current date and time, and then moved into old manifests. eg `Images_manifest_2017_06_27T14_39_58.md5`
* if the source manifest is an actual sidecar, nothing will be done.

