### PR TITLE
BITC refactor

### DIFF
--- a/bitc.py
+++ b/bitc.py
@@ -1,236 +1,243 @@
 #!/usr/bin/env python
-
+'''
+Accept options from command line and make access copy.
+Use bitc.py -h for help
+'''
 import argparse
 import subprocess
 import sys
 import os
 from ififuncs import hashlib_md5
-from glob import glob
-from sys import platform as _platform
 
 
 def getffprobe(variable, streamvalue, which_file):
-    variable = subprocess.check_output(['ffprobe',
-                                                '-v', 'error',
-                                                '-select_streams', 'v:0',
-                                                '-show_entries',
-                                                streamvalue,
-                                                '-of', 'default=noprint_wrappers=1:nokey=1',
-                                                which_file])
+    '''
+    Returns a specific ffprobe technical metadata value.
+    This is a good candidate to be moved to ififuncs.
+    '''
+    variable = subprocess.check_output([
+        'ffprobe',
+        '-v', 'error',
+        '-select_streams', 'v:0',
+        '-show_entries',
+        streamvalue,
+        '-of', 'default=noprint_wrappers=1:nokey=1',
+        which_file
+    ])
     return variable
 
 
-def set_options(input):
-    parser = argparse.ArgumentParser(description='IFI Irish Film Institute H264 FFMPEG Encoder.'
-                                     ' Written by Kieran O\'Leary.')
-    parser.add_argument('input')
+def set_options():
+    '''
+    Parse command line options.
+    '''
+    parser = argparse.ArgumentParser(
+        description='IFI Irish Film Institute H264 FFMPEG Encoder.'
+        ' Written by Kieran O\'Leary.'
+    )
     parser.add_argument(
-                        '-clean',
-                        action='store_true',help='Disables watermark and timecode for a clean image')
+        'input'
+    )
     parser.add_argument(
-                        '-yadif',
-                        action='store_true',help='Yet Another DeInterlace Filter')
+        '-clean',
+        action='store_true',
+        help='Disables watermark and timecode for a clean image'
+    )
     parser.add_argument(
-                        '-crf',
-                        help='Set quality. Default is 23, lower number = large file/high quality, high number = small file/poor quality')
+        '-watermark',
+        action='store_true',
+        help='Disables timecode and only displays watermark'
+    )
     parser.add_argument(
-                        '-o',
-                        help='Set output directory. The default directory is the same directory as input.')
+        '-timecode',
+        action='store_true',
+        help='Disables watermark and only displays timecode'
+    )
     parser.add_argument(
-                        '-scale',
-                        help='Rescale video.'
-                        ' Usage: -scale 1920x1080 or -scale 720x576 etc')
+        '-yadif',
+        action='store_true',
+        help='Yet Another DeInterlace Filter'
+    )
     parser.add_argument(
-                        '-md5',
-                        action='store_true',
-                        help='Get md5 sidecar for your output file')
+        '-crf',
+        help='Set quality. Default is 23, lower number = large file/high quality, high number = small file/poor quality'
+    )
     parser.add_argument(
-                        '-map',
-                        action='store_true',
-                        help='Force default mapping, eg. 1 audio/video stream')
+        '-o',
+        help='Set output directory. The default directory is the same directory as input.'
+    )
+    parser.add_argument(
+        '-scale',
+        help='Rescale video.'
+        ' Usage: -scale 1920x1080 or -scale 720x576 etc'
+    )
+    parser.add_argument(
+        '-md5',
+        action='store_true',
+        help='Get md5 sidecar for your output file'
+    )
+    parser.add_argument(
+        '-map',
+        action='store_true',
+        help='Force default mapping, eg. 1 audio/video stream'
+    )
 
     parser.add_argument(
-                        '-player',
-                        action='store_true',
-                        help='uses yadif, 4:3 DAR with 1:1 PAR, with no watermark or timecode.')
-    args = parser.parse_args()
+        '-player',
+        action='store_true',
+        help='uses yadif, 4:3 DAR with 1:1 PAR, with no watermark or timecode.'
+    )
+    return parser.parse_args()
 
+
+def build_filter(args, filename):
+    '''
+    Builds the ffmpeg -vf filtergraph, if needed.
+    '''
     h264_options = []
-
+    filter_list = []
+    filtergraph = ''
     if args.yadif:
-        h264_options.append('-yadif')
+        h264_options.append('yadif')
+    if args.scale:
+        h264_options.append('scale=%s' % args.scale)
+        # width_height = args.scale
+    if args.player:
+        args.clean = True
+        args.yadif = True
+    if not args.clean:
+        drawtext_option = setup_drawtext(args, filename)
+        h264_options.append(drawtext_option)
+    for option in h264_options:
+        filtergraph += option + ','
+    if len(filtergraph) > 0:
+        if filtergraph[-1] == ',':
+            filtergraph = filtergraph[:-1]
+        filter_list = ['-vf', filtergraph]
+        print filter_list
+    return filter_list
+
+
+def get_filenames(args):
+    '''
+    Get information about filenames, paths etc.
+    '''
+    cli_input = args.input
+    # Input, either file or firectory, that we want to process.
+    # Store the directory containing the input file/directory.
+    wd = os.path.dirname(cli_input)
+    if wd == '':
+        cli_input = os.path.join(os.getcwd(), args.input)
+    # Check if input is a file.
+    # AFAIK, os.path.isfile only works if full path isn't present.
+    if os.path.isfile(cli_input):
+        video_files = []                       # Create empty list
+        video_files.append(cli_input)  # Add filename to list
+    # Check if input is a directory.
+    elif os.path.isdir(cli_input):
+        for files in os.listdir(cli_input):
+            if files.endswith(('.mov', '.mp4', '.mxf', '.mkv', '.avi')):
+                if files[0] != '.':
+                    files.append(video_files)
+    # Prints some stuff if input isn't a file or directory.
+    else:
+        print "Your input isn't a file or a directory."
+    return video_files
+
+
+def setup_drawtext(args, filename):
+    '''
+    Sets up the filtergraphs for either timecode, watermark or both.
+    '''
+    video_height = float(getffprobe('video_height', 'stream=height', filename))
+    # Calculate appropriate font size
+    font_size = video_height / 12
+    watermark_size = video_height / 14
+    if sys.platform == "darwin":
+        font_path = "fontfile=/Library/Fonts/AppleGothic.ttf"
+    elif sys.platform == "linux2":
+        font_path = "fontfile=/usr/share/fonts/truetype/freefont/FreeSerifBold.ttf"
+    elif sys.platform == "win32":
+        font_path = "'fontfile=C\:\\\Windows\\\Fonts\\\\'arial.ttf'"
+    # Get starting timecode in a raw state that requires processing further on in the script.
+    timecode_test_raw = getffprobe('timecode_test_raw', 'format_tags=timecode:stream_tags=timecode', filename)
+    framerate = getffprobe('get_frame_rate', 'stream=avg_frame_rate', filename).rstrip()
+    # This tests if there is actually a timecode present in the file.
+    if not timecode_test_raw:
+        # The timecode needs to be phrased in a way unique to each operating system.
+        # Note the backslashes.
+        # This section makes up a timecode if none is present in the file.
+        if sys.platform == "darwin" or sys.platform == "linux2":
+            timecode_test = '01\\\:00\\\:00\\\:00'
+        elif sys.platform == "win32":
+            timecode_test = '01\:00\:00\:00'
+    else:
+        # If timecode is present, this will escape the colons
+        # so that it is compatible with each operating system.
+        if sys.platform == "darwin" or sys.platform == "linux2":
+            timecode_test = timecode_test_raw.replace(':', '\\\:').rstrip()
+        elif sys.platform == "win32":
+            timecode_test = timecode_test_raw.replace(':', '\\:').rstrip()
+    # This removes the new line character from the framemrate.
+    timecode_option = "drawtext=%s:fontcolor=white:fontsize=%s:timecode=%s:rate=%s:boxcolor=0x000000AA:box=1:x=(w-text_w)/2:y=h/1.2" % (font_path, font_size, timecode_test, framerate)
+    watermark_option = "drawtext=%s:fontcolor=white:text='IFI IRISH FILM ARCHIVE':x=(w-text_w)/2:y=(h-text_h)/2:fontsize=%s:alpha=0.4"  % (font_path, watermark_size)
+    bitc_watermark = timecode_option + ',' + watermark_option
+    if args.timecode:
+        return timecode_option
+    elif args.watermark:
+        return watermark_option
+    else:
+        return bitc_watermark
+
+
+def main():
+    '''
+    Launch the various functions that will make a h264/mp4 access copy.
+    '''
+    args = set_options()
+    video_files = get_filenames(args)
+    for filename in video_files:
+        filter_list = build_filter(args, filename)
+        make_h264(filename, args, filter_list)
+
+
+def make_h264(filename, args, filter_list):
+    '''
+    Launches the actuall ffmpeg process using all the info gleaned so far.
+    '''
     if args.crf:
         crf_value = args.crf
     else:
         crf_value = '23'
-
-    if args.scale:
-        h264_options.append('-scale')
-        width_height = args.scale
-    if args.player:
-        args.clean = True
-        args.yadif = True
-        crf_value = '18'
-
-    if args.clean:
-        bitc = False
-        drawtext_options = []
+    if args.o:
+        output = args.o + '/' + filename + "_h264.mov"
     else:
-        bitc = True
-        h264_options.append('bitc')
-
-    number_of_effects =  len(h264_options)
-
-     # Input, either file or firectory, that we want to process.
-    input = args.input
-
-    # Store the directory containing the input file/directory.
-    wd = os.path.dirname(input)
-    if wd == '':
-        wd = os.getcwd()
-    # Change current working directory to the value stored as "wd"
-    os.chdir(wd)
-
-    # Store the actual file/directory name without the full path.
-    file_without_path = os.path.basename(input)
-
-    # Check if input is a file.
-    # AFAIK, os.path.isfile only works if full path isn't present.
-    if os.path.isfile(file_without_path):
-        video_files = []                       # Create empty list
-        video_files.append(file_without_path)  # Add filename to list
-
-    # Check if input is a directory.
-    elif os.path.isdir(file_without_path):
-        os.chdir(file_without_path)
-        video_files = (
-            glob('*.mov') +
-            glob('*.mp4') +
-            glob('*.mxf') +
-            glob('*.mkv') +
-            glob('*.avi')
-        )
-
-    # Prints some stuff if input isn't a file or directory.
-    else:
-        print "Your input isn't a file or a directory."
-    return video_files,crf_value, number_of_effects, args,bitc
-
-def main(sidecar):
-    video_files,crf_value, number_of_effects, args,bitc = set_options(sys.argv[1])
-    get_bitc(video_files, crf_value, number_of_effects, args, bitc, sidecar)
-
-def get_bitc(video_files, crf_value, number_of_effects, args, bitc, sidecar):
-    drawtext_options = []
-    for filename in video_files:
-        if args.o:
-            output = args.o + '/' + filename + "_h264.mov"
-        elif sidecar == 'proxy_folder':
-            proxy_folder = os.path.dirname(os.path.abspath(filename)) + '/proxy'
-            if not os.path.isdir(proxy_folder):
-                os.makedirs(proxy_folder)
-            output = proxy_folder + '/' + filename + "_h264.mov"
-        else:
-            output = filename + "_h264.mov"
-
-        height = subprocess.check_output(['mediainfo','--Language=raw','--Full',"--Inform=Video;%Height%", filename]).rstrip()
-        pixel_aspect_ratio = subprocess.check_output(['mediainfo','--Language=raw','--Full',"--Inform=Video;%PixelAspectRatio%", filename]).rstrip()
-
-        ffmpeg_args =   ['ffmpeg',
-                '-i', filename,
-                '-c:a', 'aac',
-                '-c:v', 'libx264',
-                '-pix_fmt', 'yuv420p',
-                '-crf', crf_value]
-
-        if not args.map:
-            ffmpeg_args.append('-map')
-            ffmpeg_args.append('0:a?')
-            ffmpeg_args.append('-map')
-            ffmpeg_args.append('0:v')
-
-        if args.yadif or args.scale or args.player or bitc :
-            ffmpeg_args.append('-vf')
-
-            if bitc:
-                video_height = float(getffprobe('video_height','stream=height', filename))
-                video_width  = float(getffprobe('video_width','stream=width', filename))
-
-                # Calculate appropriate font size
-                font_size = video_height / 12
-                watermark_size = video_height / 14
-
-                if _platform == "darwin":
-                    font_path= "fontfile=/Library/Fonts/AppleGothic.ttf"
-                elif _platform == "linux2":
-                    font_path= "fontfile=/usr/share/fonts/truetype/freefont/FreeSerifBold.ttf"
-                elif _platform == "win32":
-                    font_path = "'fontfile=C\:\\\Windows\\\Fonts\\\\'arial.ttf'"
-
-                # Get starting timecode in a raw state that requires processing further on in the script.
-                timecode_test_raw = getffprobe('timecode_test_raw','format_tags=timecode:stream_tags=timecode', filename)
-                get_framerate = getffprobe('get_frame_rate','stream=avg_frame_rate', filename)
-
-                # This tests if there is actually a timecode present in the file.
-                if not timecode_test_raw:
-                    # The timecode needs to be phrased in a way unique to each operating system.
-                    # Note the backslashes.
-                    # This section makes up a timecode if none is present in the file.
-                    if _platform == "darwin" or _platform == "linux2":
-                        timecode_test = '01\\\:00\\\:00\\\:00'
-                    elif _platform == "win32":
-                        timecode_test = '01\:00\:00\:00'
-
-                else:
-                    # If timecode is present, this will escape the colons
-                    # so that it is compatible with each operating system.
-                    if _platform == "darwin" or _platform == "linux2":
-                        timecode_test = timecode_test_raw.replace(':', '\\\:').replace('\n', '')
-                    elif _platform == "win32":
-                        timecode_test = timecode_test_raw.replace(':', '\\:').replace('\n', '').replace('\r', '')
-
-                # This removes the new line character from the framemrate.
-                fixed_framerate = get_framerate.rstrip()
-                filter_options = ''
-                #all these prints are just for testing. Will be removed later.
-
-                if _platform == "darwin" or _platform == "linux2":
-                    placeholder = ''
-                    drawtext_options = ["drawtext=%s:fontcolor=white:fontsize=%s:timecode=%s:rate=%s:boxcolor=0x000000AA:box=1:x=(w-text_w)/2:y=h/1.2,drawtext=%s:fontcolor=white:text='IFI IRISH FILM ARCHIVE':x=(w-text_w)/2:y=(h-text_h)/2:fontsize=%s:alpha=0.4"  % (font_path,font_size, timecode_test, fixed_framerate, font_path,watermark_size)]
-
-                elif _platform == "win32":
-                    drawtext_options = ["drawtext=%s:fontcolor=white:fontsize=%s:timecode=%s:rate=%s:boxcolor=0x000000AA:box=1:x=(w-text_w)/2:y=h/1.2',drawtext=%s:fontcolor=white:text='IFI IRISH FILM ARCHIVE':x=(w-text_w)/2:y=(h-text_h)/2:fontsize=%s:alpha=0.4'"  % (font_path,font_size, timecode_test, fixed_framerate, font_path,watermark_size)]
-
-            if args.yadif:
-                if args.player:
-                    if height =='576':
-                        if pixel_aspect_ratio == '1.000':
-                            ffmpeg_args.append('yadif,scale=768:576')
-                elif args.clean:
-                    ffmpeg_args.append(' yadif')
-                else:
-                    drawtext_options[-1] += ',yadif'
-            if args.scale:
-                if args.clean:
-                    if number_of_effects > 1:
-                        ffmpeg_args[-1] += (',scale=%s' % width_height)
-                    else:
-                        ffmpeg_args.append('scale=%s' % width_height)
-                else:
-                    drawtext_options[-1] += (',scale=%s' % width_height)
-            if len(drawtext_options) > 0:
-                for i in drawtext_options:
-                    ffmpeg_args.append(i)
-
-        ffmpeg_args.append(output)
-        print ffmpeg_args
-        subprocess.call(ffmpeg_args)
-        if args.md5:
-            manifest =  '%s_manifest.md5' % filename
-            print 'Generating md5 sidecar...'
-            h264_md5 = hashlib_md5(filename)
-            with open(manifest,'wb') as fo:
-                fo.write('%s  %s' % (h264_md5, filename))
+        output = filename + "_h264.mov"
+    ffmpeg_args = [
+        'ffmpeg',
+        '-i', filename,
+        '-c:a', 'aac',
+        '-c:v', 'libx264',
+        '-pix_fmt', 'yuv420p',
+        '-crf', crf_value
+    ]
+    if not args.map:
+        ffmpeg_args.append('-map')
+        ffmpeg_args.append('0:a?')
+        ffmpeg_args.append('-map')
+        ffmpeg_args.append('0:v')
+    if len(filter_list) > 0:
+        for _filter in filter_list:
+            ffmpeg_args.append(_filter)
+    ffmpeg_args.append(output)
+    print ffmpeg_args
+    subprocess.call(ffmpeg_args)
+    if args.md5:
+        manifest = '%s_manifest.md5' % filename
+        print 'Generating md5 sidecar...'
+        h264_md5 = hashlib_md5(filename)
+        with open(manifest, 'wb') as fo:
+            fo.write('%s  %s' % (h264_md5, filename))
 
 if __name__ == "__main__":
-    main('sidecar')
+    main()

--- a/bitc.py
+++ b/bitc.py
@@ -210,7 +210,7 @@ def make_h264(filename, args, filter_list):
     else:
         crf_value = '23'
     if args.o:
-        output = args.o + '/' + filename + "_h264.mov"
+        output = args.o + '/' + os.path.basename(filename) + "_h264.mov"
     else:
         output = filename + "_h264.mov"
     ffmpeg_args = [

--- a/sha512deep.py
+++ b/sha512deep.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python
-
+'''
+Make a sha512 manifest
+'''
 import os
 import subprocess
 import sys
 
 
 def main():
+    '''
+    Super basic sha512 manifest generator.
+    Haven't looked at this in ages, needs a lot more work!
+    '''
     source = sys.argv[1]
     total_file_count = 0
     print 'Determining number of files to be processed'
-    for root, directories, filenames in os.walk(source):
+    for root, _, filenames in os.walk(source):
         for files in filenames:
             total_file_count += 1
     progress_counter = 1
     manifest = os.path.dirname(source) + '/manifest_sha512.txt'
-    for root, directories, filenames in os.walk(source):
+    for root, _, filenames in os.walk(source):
         for files in filenames:
             print 'processing %s - %d of %d' % (
                 files, progress_counter, total_file_count
@@ -23,8 +29,8 @@ def main():
                 ['openssl', 'sha512', '-r', os.path.join(root, files)]
                 )
             root2 = root.replace(os.path.dirname(source), '')
-            with open(manifest, "ab") as fo:
-                fo.write(
+            with open(manifest, "ab") as manifest_object:
+                manifest_object.write(
                     sha512[:128] + ' ' + os.path.join(
                         root2, files
                         ).replace("\\", "/") + '\n'


### PR DESCRIPTION
This is a complete rewrite of `bitc.py`

The original was one of my first python scripts, but even though i cleaned it up a little every now and then, it was pretty broken, difficult to maintain and improve. This rewrite breaks everything up into more functions, and allows for the easier seperation/combination of watermark/BITC. new options added are `-watermark` and `-timecode`.
Things seem to work well but further testing is required. As `bitc.py` is used in other scripts, it must also be tested that the behaviour does not change.