### PR TITLE
adds ffv1/mkv validation via mediaconch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ table of contents
 
 1. [summary](https://github.com/kieranjol/IFIscripts#summary)
 2. [Arrangement](https://github.com/kieranjol/IFIscripts#arrangement)
-    * [sipcreator.py](https://github.com/kieranjol/IFIscripts#sipcreator)
+    * [sipcreator.py](https://github.com/kieranjol/IFIscripts#sipcreatorpy)
 3. [Transcodes](https://github.com/kieranjol/IFIscripts#transcodes)
     * [makeffv1.py](https://github.com/kieranjol/IFIscripts#makeffv1py)
     * [bitc.py](https://github.com/kieranjol/IFIscripts#bitcpy)
@@ -35,6 +35,7 @@ table of contents
 	* [batchrename.py](https://github.com/kieranjol/IFIscripts#batchrename)
 7. [Quality Control](https://github.com/kieranjol/IFIscripts#quality-control)
     * [qctools.py](https://github.com/kieranjol/IFIscripts#qctoolspy)
+    * [ffv1mkvvalidate.py](https://github.com/kieranjol/IFIscripts#ffv1mkvvalidatespy)
 8. [Specific Workflows](https://github.com/kieranjol/IFIscripts#specific-workflows)
     * [mezzaninecheck.py](https://github.com/kieranjol/IFIscripts#mezzaninecheckpy)
     * [loopline.py](https://github.com/kieranjol/IFIscripts#looplinepy)
@@ -200,6 +201,13 @@ Note: Documentation template has been copied from [mediamicroservices](https://g
 * Generate QCTools xml.gz sidecar files which will load immediately in QCTools.
 * Usage for single file - `qctools.py filename.mov`
 * Usage for batch processing all videos in a directory - `qctools.py directory_name`
+
+
+### ffv1mkvvalidate.py ###
+* Validates Matroska files using mediaconch.
+* An XML report will be written to the metadata directory.
+* A log will appear on the desktop, which will be merged into the SIP log in /logs.
+* Usage for batch processing all videos in a directory - `ffv1mkvvalidate.py directory_name`
 
 ## Specific Workflows ##
 

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -47,18 +47,16 @@ def launch_mediaconch(source, user):
     log_name_source = "%s/%s_mediaconch_validation.log" % (desktop_logs_dir, log_name_source_)
     ififuncs.generate_log(
         log_name_source,
-        'EVENT = mediaconchvalidation.py started'
+        'EVENT = ffv1mkvvalidate.py started'
     )
     ififuncs.generate_log(
         log_name_source,
-        'EVENT = agentName=%s' % user
+        'agentName=%s' % user
     )
-    '''
     ififuncs.generate_log(
         log_name_source,
-        'eventDetail=mediaconchvalidation.py %s' % ififuncs.get_script_version('mediaconchvalidation.py')
+        'eventDetail=mediaconchvalidation.py %s' % ififuncs.get_script_version('ffv1mkvvalidate.py')
     )
-    '''
     mediaconch_version = subprocess.check_output(['mediaconch', '-v']).rstrip()
 
     ififuncs.generate_log(

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -18,12 +18,20 @@ def logname_check(basename, logs_dir):
     '''
     makeffv1_logfile = os.path.join(
         logs_dir, basename +'.mov_log.log')
+    generic_logfile = os.path.join(
+        logs_dir, basename +'_log.log')
+    mxf_logfile = os.path.join(
+        logs_dir, basename +'.mxf_log.log')
     sipcreator_logfile = os.path.join(
         logs_dir, basename + '_sip_log.log')
     mkv_log = os.path.join(
         logs_dir, basename +'.mkv_log.log')
     if os.path.isfile(makeffv1_logfile):
         return makeffv1_logfile
+    if os.path.isfile(generic_logfile):
+        return generic_logfile
+    if os.path.isfile(mxf_logfile):
+        return mxf_logfile
     if os.path.isfile(sipcreator_logfile):
         return sipcreator_logfile
     if os.path.isfile(mkv_log):
@@ -76,6 +84,9 @@ def setup(full_path, user):
     manifest = os.path.join(
         sip_root, os.path.basename(parent_dir) + '_manifest.md5'
     )
+    if not os.path.isfile(manifest):
+        print 'manifest does not exist %s' % manifest
+        return 'skipping'
     if os.path.isdir(metadata_dir):
         mediaconch_xmlfile_basename = '%s_mediaconch_validation.xml' % filename
         mediaconch_xmlfile = os.path.join(

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -22,6 +22,10 @@ def log_results(manifest, log, parent_dir):
     logs_dir = os.path.join(sip_dir, 'logs')
     logfile = os.path.join(logs_dir, logname)
     print logfile
+    ififuncs.generate_log(
+        log,
+        'EVENT = Logs consolidation - Log from %s merged into %s' % (log, logfile)
+    )
     if os.path.isfile(logfile):
         with open(log, 'r') as fo:
             validate_log = fo.readlines()

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -10,6 +10,26 @@ import time
 from lxml import etree
 import ififuncs
 
+
+def logname_check(basename, logs_dir):
+    '''
+    Currently we have a few different logname patterns in our packages.
+    This attempts to return the appropriate one.
+    '''
+    makeffv1_logfile = os.path.join(
+        logs_dir, basename +'.mov_log.log')
+    sipcreator_logfile = os.path.join(
+        logs_dir, basename + '_sip_log.log')
+    mkv_log = os.path.join(
+        logs_dir, basename +'.mkv_log.log')
+    if os.path.isfile(makeffv1_logfile):
+        return makeffv1_logfile
+    if os.path.isfile(sipcreator_logfile):
+        return sipcreator_logfile
+    if os.path.isfile(mkv_log):
+        return mkv_log
+
+
 def log_results(manifest, log, parent_dir):
     '''
     Updates the existing log file. This is copy pasted from validate.py.
@@ -17,11 +37,10 @@ def log_results(manifest, log, parent_dir):
     '''
     updated_manifest = []
     basename = os.path.basename(manifest).replace('_manifest.md5', '')
-    logname = basename + '.mov_log.log'
     sip_dir = parent_dir
     logs_dir = os.path.join(sip_dir, 'logs')
+    logname = logname_check(basename, logs_dir)
     logfile = os.path.join(logs_dir, logname)
-    print logfile
     ififuncs.generate_log(
         log,
         'EVENT = Logs consolidation - Log from %s merged into %s' % (log, logfile)
@@ -35,7 +54,7 @@ def log_results(manifest, log, parent_dir):
     with open(manifest, 'r') as manifesto:
         manifest_lines = manifesto.readlines()
         for lines in manifest_lines:
-            if logname in lines:
+            if os.path.basename(logname) in lines:
                 lines = lines[:31].replace(lines[:31], ififuncs.hashlib_md5(logfile)) + lines[32:]
             updated_manifest.append(lines)
     with open(manifest, 'wb') as fo:

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+'''
+Runs mediaconch on FFV1/MKV files.
+The process will validate the files against the FFV1/MKV/PCM standards.
+'''
+import os
+import subprocess
+import sys
+import time
+from lxml import etree
+import ififuncs
+
+def log_results(manifest, log, parent_dir):
+    '''
+    Updates the existing log file. This is copy pasted from validate.py.
+    Eventally, both functions should be merged and moved into ififuncs.
+    '''
+    updated_manifest = []
+    basename = os.path.basename(manifest).replace('_manifest.md5', '')
+    logname = basename + '.mkv_log.log'
+    sip_dir = parent_dir
+    logs_dir = os.path.join(sip_dir, 'logs')
+    logfile = os.path.join(logs_dir, logname)
+    print logfile
+    if os.path.isfile(logfile):
+        with open(log, 'r') as fo:
+            validate_log = fo.readlines()
+        with open(logfile, 'ab') as ba:
+            for lines in validate_log:
+                ba.write(lines)
+    with open(manifest, 'r') as manifesto:
+        manifest_lines = manifesto.readlines()
+        for lines in manifest_lines:
+            if logname in lines:
+                lines = lines[:31].replace(lines[:31], ififuncs.hashlib_md5(logfile)) + lines[32:]
+            updated_manifest.append(lines)
+    with open(manifest, 'wb') as fo:
+        for lines in updated_manifest:
+            fo.write(lines)
+
+def launch_mediaconch(source, user):
+    '''
+    Run mediaconch on files.
+    '''
+    desktop_logs_dir = ififuncs.make_desktop_logs_dir()
+    log_name_source_ = os.path.basename(source) + time.strftime("_%Y_%m_%dT%H_%M_%S")
+    log_name_source = "%s/%s_mediaconch_validation.log" % (desktop_logs_dir, log_name_source_)
+    ififuncs.generate_log(
+        log_name_source,
+        'EVENT = mediaconchvalidation.py started'
+    )
+    ififuncs.generate_log(
+        log_name_source,
+        'EVENT = agentName=%s' % user
+    )
+    '''
+    ififuncs.generate_log(
+        log_name_source,
+        'eventDetail=mediaconchvalidation.py %s' % ififuncs.get_script_version('mediaconchvalidation.py')
+    )
+    '''
+    mediaconch_version = subprocess.check_output(['mediaconch', '-v']).rstrip()
+
+    ififuncs.generate_log(
+        log_name_source,
+        'agentName=mediaconch, agentversion=%s' % mediaconch_version
+    )
+    full_path = source
+    filename = os.path.basename(full_path)
+    object_dir = os.path.dirname(full_path)
+    parent_dir = os.path.dirname(object_dir)
+    sip_root = os.path.dirname(parent_dir)
+    manifest = os.path.join(sip_root, os.path.basename(parent_dir) + '_manifest.md5')
+    metadata_dir = os.path.join(parent_dir, 'metadata')
+    if os.path.isdir(metadata_dir):
+        mediaconch_xmlfile_basename = '%s_mediaconch_validation.xml' % filename
+        mediaconch_xmlfile = os.path.join(metadata_dir, mediaconch_xmlfile_basename)
+        if not os.path.isfile(mediaconch_xmlfile):
+            mediaconch_cmd = [
+                'mediaconch',
+                '-fx',
+                full_path
+            ]
+            print 'Mediaconch is analyzing %s' % full_path
+            mediaconch_output = subprocess.check_output(mediaconch_cmd)
+            with open(mediaconch_xmlfile, 'wb') as xmlfile:
+                xmlfile.write(mediaconch_output)
+            ififuncs.manifest_update(manifest, mediaconch_xmlfile)
+        else:
+            print 'mediaconch xml already exists'
+    else:
+        print 'no metadata directory found. Exiting.'
+    return log_name_source, mediaconch_xmlfile, manifest, parent_dir
+
+def parse_mediaconch(mediaconch_xml):
+    '''
+    Parses the mediaconch implementation check report.
+    Returns a dictionary containing the overview of the PASS/FAILs.
+    '''
+    mediaconch_xml_object = etree.parse(mediaconch_xml)
+    mediaconch_namespace = mediaconch_xml_object.xpath('namespace-uri(.)')
+    validation_outcome = mediaconch_xml_object.xpath(
+        '/ns:MediaConch/ns:media/ns:implementationChecks',
+        namespaces={'ns':mediaconch_namespace}
+    )
+    return validation_outcome[0].attrib
+
+
+def main():
+    '''
+    Launches the functions that will validate your FFV1/MKV files.
+    '''
+    user = ififuncs.get_user()
+    for root, _, filenames in os.walk(sys.argv[1]):
+        for filename in filenames:
+            if filename[0] != '.':
+                if filename.endswith('.mkv'):
+                    log_name_source, mediaconch_xmlfile, manifest, parent_dir = launch_mediaconch(
+                        os.path.join(root, filename), user
+                    )
+                    validation_outcome = parse_mediaconch(mediaconch_xmlfile)
+                    print str(validation_outcome)
+                    if int(validation_outcome['fail_count']) > 0:
+                        print 'Validation failed!'
+                        event_outcome = 'fail'
+                    elif int(validation_outcome['fail_count']) == 0:
+                        print 'validation successful'
+                        event_outcome = 'pass'
+                    ififuncs.generate_log(
+                        log_name_source,
+                        'EVENT = eventType=validation, eventOutcome=%s, eventDetail=%s' % (event_outcome, str(validation_outcome))
+                    )
+                    log_results(manifest, log_name_source, parent_dir)
+
+
+if __name__ == '__main__':
+    main()
+
+

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import time
+import argparse
 from lxml import etree
 import ififuncs
 
@@ -139,13 +140,30 @@ def parse_mediaconch(mediaconch_xml):
     )
     return validation_outcome[0].attrib
 
-
+def parse_args():
+    '''
+    Parse command line arguments.
+    '''
+    parser = argparse.ArgumentParser(
+        description='Recursively validates all MKV files using mediaconch'
+        'Report is written in XML format to the metadata folder and'
+        'manifests and logs are updated'
+        ' Written by Kieran O\'Leary.'
+    )
+    parser.add_argument(
+        'input',
+        help='full path of input directory. All mkv files will be processed.'
+    )
+    parsed_args = parser.parse_args()
+    return parsed_args
 def main():
     '''
     Launches the functions that will validate your FFV1/MKV files.
     '''
+    args = parse_args()
+    source = args.input
     user = ififuncs.get_user()
-    for root, _, filenames in os.walk(sys.argv[1]):
+    for root, _, filenames in os.walk(source):
         for filename in filenames:
             if filename[0] != '.' and filename.endswith('.mkv'):
                 if setup(os.path.join(root, filename), user) == 'skipping':

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -17,7 +17,7 @@ def log_results(manifest, log, parent_dir):
     '''
     updated_manifest = []
     basename = os.path.basename(manifest).replace('_manifest.md5', '')
-    logname = basename + '.mkv_log.log'
+    logname = basename + '.mov_log.log'
     sip_dir = parent_dir
     logs_dir = os.path.join(sip_dir, 'logs')
     logfile = os.path.join(logs_dir, logname)

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -55,7 +55,7 @@ def launch_mediaconch(source, user):
     )
     ififuncs.generate_log(
         log_name_source,
-        'eventDetail=mediaconchvalidation.py %s' % ififuncs.get_script_version('ffv1mkvvalidate.py')
+        'eventDetail=ffv1mkvvalidate.py %s' % ififuncs.get_script_version('ffv1mkvvalidate.py')
     )
     mediaconch_version = subprocess.check_output(['mediaconch', '-v']).rstrip()
 

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -726,9 +726,7 @@ def manifest_update(manifest, path):
             if root2[0] == '\\':
                 root2 = root2[1:]
         except: IndexError
-        print root2
         manifest_generator += md5[:32] + '  ' + root2.replace("\\", "/") + '\n'
-        print manifest_generator
         for i in original_lines:
             manifest_generator += i
     manifest_list = manifest_generator.splitlines()
@@ -750,7 +748,6 @@ def check_for_uuid(args):
             return os.path.basename(args.i[0])
         else:
             returned_dir = check_for_sip(args.i)
-            print returned_dir
             if returned_dir is None:
                 return False
             uuid_check = os.path.basename(returned_dir)
@@ -784,12 +781,10 @@ def checksum_replace(manifest, logname):
     new_checksum = hashlib_md5(logname)
     with open(manifest, 'r') as manifesto:
         manifest_lines = manifesto.readlines()
-        print manifest_lines, 11
         for lines in manifest_lines:
             if os.path.basename(logname) in lines:
                 lines = lines[31:].replace(lines[31:], new_checksum + lines[32:])
             updated_manifest.append(lines)
-    print updated_manifest, 22
     with open(manifest, 'wb') as fo:
         for lines in updated_manifest:
             fo.write(lines)

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+'''
+A collection of functions that other scripts can use.
+
+'''
 import subprocess
 import sys
 import time
@@ -48,6 +52,21 @@ def make_mediainfo(xmlfilename, xmlvariable, inputfilename):
     with open(xmlfilename, "w+") as fo:
         xmlvariable = subprocess.check_output(mediainfo_cmd)
         fo.write(xmlvariable)
+
+
+def make_mediaconch(full_path, mediaconch_xmlfile):
+    '''
+    Creates a mediaconch implementation check XML report.
+    '''
+    mediaconch_cmd = [
+        'mediaconch',
+        '-fx',
+        full_path
+    ]
+    print 'Mediaconch is analyzing %s' % full_path
+    mediaconch_output = subprocess.check_output(mediaconch_cmd)
+    with open(mediaconch_xmlfile, 'wb') as xmlfile:
+        xmlfile.write(mediaconch_output)
 
 
 def make_qctools(input):


### PR DESCRIPTION
Testing on actual SIPs needs to be completed, but this works well on test files.

* Validates Matroska files using mediaconch. This will determine if your FFV1 streams in MKV containers validate against the actual IETF draft standards. as determined by the CELLAR working group.
* An XML report will be written to the metadata directory.
* A log will appear on the desktop, which will be merged into the existing SIP log in /logs.
* Usage for batch processing all videos in a directory - `ffv1mkvvalidate.py directory_name`
* PREMIS-y language is used in the logfile - eventType=Validation etc

More to be done - cleanup, optimising, better logging etc. Add support for new SIP folder structures as well as the classic makeffv1.py structure.
For reference: here's  what is added to the logfile after this script runs :+1: 
```
2017-07-16T13:30:32 kieranjol EVENT = agentName=Kieran O'Leary 
2017-07-16T13:30:32 kieranjol agentName=mediaconch, agentversion=MediaConch Command Line Interface 17.06.20170708 
2017-07-16T13:30:32 kieranjol EVENT = eventType=validation, eventOutcome=pass, eventDetail={'pass_count': '18', 'fail_count': '0', 'checks_run': '18'} 

```
pinging  @vphill as  this script could be run after makeffv1.py