### PR TITLE
creates PREMIS CSV implementation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,25 @@ table of contents
 1. [summary](https://github.com/kieranjol/IFIscripts#summary)
 2. [Arrangement](https://github.com/kieranjol/IFIscripts#arrangement)
     * [sipcreator.py](https://github.com/kieranjol/IFIscripts#sipcreator)
-3. [Transcodes](https://github.com/kieranjol/IFIscripts#transcodes)
+3. [PREMIS](https://github.com/kieranjol/IFIscripts#PREMIS)
+    * [premisobjects.py](https://github.com/kieranjol/IFIscripts#premisobjectspy)
+    * [premiscsv.py](https://github.com/kieranjol/IFIscripts#premiscsvpy)
+4. [Transcodes](https://github.com/kieranjol/IFIscripts#transcodes)
     * [makeffv1.py](https://github.com/kieranjol/IFIscripts#makeffv1py)
     * [bitc.py](https://github.com/kieranjol/IFIscripts#bitcpy)
     * [prores.py](https://github.com/kieranjol/IFIscripts#prorespy)
     * [concat.py](https://github.com/kieranjol/IFIscripts#concatpy)
-4. [Digital Cinema Package Scripts](https://github.com/kieranjol/IFIscripts#digital-cinema-package-scripts)
+5. [Digital Cinema Package Scripts](https://github.com/kieranjol/IFIscripts#digital-cinema-package-scripts)
 	* [dcpaccess.py](https://github.com/kieranjol/IFIscripts#dcpaccesspy)
     * [dcpfixity.py](https://github.com/kieranjol/IFIscripts#dcpfixitypy)
     * [dcpsubs2srt.py](https://github.com/kieranjol/IFIscripts#dcpsubs2srtpy)
-5. [Fixity Scripts](https://github.com/kieranjol/IFIscripts#fixity-scripts)
+6. [Fixity Scripts](https://github.com/kieranjol/IFIscripts#fixity-scripts)
     * [copyit.py](https://github.com/kieranjol/IFIscripts#copyitpy)
     * [manifest.py](https://github.com/kieranjol/IFIscripts#manifestpy)
     * [sha512deep.py](https://github.com/kieranjol/IFIscripts#sha512deeppy)
     * [validate.py](https://github.com/kieranjol/IFIscripts#validatepy)
     * [batchfixity.py](https://github.com/kieranjol/IFIscripts#batchfixitypy)
-6. [Image Sequences](https://github.com/kieranjol/IFIscripts#image-sequences)
+7. [Image Sequences](https://github.com/kieranjol/IFIscripts#image-sequences)
     * [makedpx.py](https://github.com/kieranjol/IFIscripts#makedpxpy)
     * [seq2ffv1.py](https://github.com/kieranjol/IFIscripts#seq2ffv1py)
     * [seq2prores.py](https://github.com/kieranjol/IFIscripts#seq2prorespy)
@@ -33,19 +36,19 @@ table of contents
     * [seq2dv.py](https://github.com/kieranjol/IFIscripts#seq2dvpy)
     * [batchmetadata.py](https://github.com/kieranjol/IFIscripts#batchmetadata)
 	* [batchrename.py](https://github.com/kieranjol/IFIscripts#batchrename)
-7. [Quality Control](https://github.com/kieranjol/IFIscripts#quality-control)
+8. [Quality Control](https://github.com/kieranjol/IFIscripts#quality-control)
     * [qctools.py](https://github.com/kieranjol/IFIscripts#qctoolspy)
-8. [Specific Workflows](https://github.com/kieranjol/IFIscripts#specific-workflows)
+9. [Specific Workflows](https://github.com/kieranjol/IFIscripts#specific-workflows)
     * [mezzaninecheck.py](https://github.com/kieranjol/IFIscripts#mezzaninecheckpy)
     * [loopline.py](https://github.com/kieranjol/IFIscripts#looplinepy)
     * [masscopy.py](https://github.com/kieranjol/IFIscripts#masscopypy)
     * [dvsip.py](https://github.com/kieranjol/IFIscripts#dvsippy)
-9. [Misc](https://github.com/kieranjol/IFIscripts#misc)
+10. [Misc](https://github.com/kieranjol/IFIscripts#misc)
     * [update.py](https://github.com/kieranjol/IFIscripts#updatepy)
     * [giffer.py](https://github.com/kieranjol/IFIscripts#gifferpy)
     * [makeuuid.py](https://github.com/kieranjol/IFIscripts#makeuuidpy)
     * [durationcheck.py](https://github.com/kieranjol/IFIscripts#durationcheck.py)
-10. [Experimental-Premis](https://github.com/kieranjol/IFIscripts#experimental-premis)
+11. [Experimental-Premis](https://github.com/kieranjol/IFIscripts#experimental-premis)
     * [premis.py](https://github.com/kieranjol/IFIscripts#premispy)
     * [revtmd.py](https://github.com/kieranjol/IFIscripts#revtmdpy)
     * [as11fixity.py](https://github.com/kieranjol/IFIscripts#as11fixitypy)
@@ -67,6 +70,22 @@ Note: Documentation template has been copied from [mediamicroservices](https://g
 * Usage for one directory - `sipcreator.py -i /path/to/directory_name -o /path/to/output_folder`
 * Usage for more than one directory - `sipcreator.py -i /path/to/directory_name1 /path/to/directory_name2 -o /path/to/output_folder`
 * Run `sipcreator.py -h` for all options.
+
+## PREMIS ##
+
+### premisobjects.py ###
+* Creates a somewhat PREMIS compliant CSV file describing objects in a package. A seperate script will need to be written in order to transform these CSV files into XML.
+* As the flat CSV structure prevents maintaining some of the complex relationships between units, some semantic units have been merged, for example:`relationship_structural_includes` is really a combination of the `relationshipType` and `relationshipSubType` units, which each have the values: `Structural` and `Includes` respectively.
+* Assumptions for now: representation UUID already exists as part of the SIP/AIP folder structure. Find a way to supply this, probably via argparse.
+* For more information, run `pydoc premisobjects `
+* Usage: `premiscsv.py path/to/SIP path/to/manifest.md5`
+
+### premiscsv.py ###
+* Extracts preservation events from an IFI plain text log file and converts to a CSV using the PREMIS data dictionary.
+* For more information, run `pydoc premiscsv`
+* Usage: - `premiscsv.py path/to/logfile.log`
+
+
 
 ## Transcodes ##
 

--- a/premiscsv.py
+++ b/premiscsv.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+'''
+Extracts preservation events from an IFI plain text log file and converts
+to a CSV using the PREMIS data dictionary
+'''
+import os
+import sys
+# from lxml import etree
+import ififuncs
+def find_events(logfile):
+    '''
+    A very hacky attempt to extract the relevant preservation events from our
+    log files.
+    '''
+    sip_test = os.path.basename(logfile).replace('_sip_log.log', '')
+    if ififuncs.validate_uuid4(sip_test) != False:
+        linking_object_identifier_value = sip_test
+    with open(logfile, 'r') as logfile_object:
+        log_lines = logfile_object.readlines()
+    for event_test in log_lines:
+        if 'eventDetail=copyit.py' in event_test:
+            logsplit = event_test.split(',')
+            for line_fragment in logsplit:
+                manifest_event = line_fragment.replace(
+                    'eventDetail', ''
+                ).replace('\n', '').split('=')[1]
+    for log_entry in log_lines:
+        valid_entries = [
+            'eventType',
+            'eventDetail=sipcreator.py',
+            'eventDetail=Mediatrace',
+            'eventDetail=Technical',
+            'eventDetail=copyit.py'
+        ]
+        for entry in valid_entries:
+            if entry in log_entry:
+                break_loop = ''
+                event_outcome = ''
+                event_detail = ''
+                event_outcome_detail_note = ''
+                event_type = ''
+                event_row = []
+                datetime = log_entry[:19]
+                logsplit = log_entry.split(',')
+                for line_fragment in logsplit:
+                    if 'eventType' in line_fragment:
+                        if 'EVENT =' in line_fragment:
+                            line_fragment = line_fragment.split('EVENT =')[1]
+                        event_type = line_fragment.replace(
+                            ' eventType=', ''
+                        ).replace('assignement', 'assignment')
+                    if ' value' in line_fragment:
+                        # this assumes that the value is the outcome of an identifier assigment.
+                        event_outcome = line_fragment[7:].replace('\n', '')
+                    # we are less concerned with events starting.
+                    if 'status=started' in line_fragment:
+                        break_loop = 'continue'
+                    if 'Generating destination manifest:' in line_fragment:
+                        break_loop = ''
+                        event_detail = manifest_event
+                    # ugh, this might run multiple times.
+                    if 'eventDetail=sipcreator.py' in log_entry:
+                        event_type = 'Information Package Creation'
+                        event_detail = line_fragment.replace(
+                            'eventDetail', ''
+                        ).replace('\n', '').split('=')[1]
+                        event_outcome_detail_note = 'Submission Information Package'
+                    if ('eventDetail=Mediatrace' in log_entry) or ('eventDetail=Technical' in log_entry):
+                        event_type = 'metadata extraction'
+                        event_outcome = log_entry.split(
+                            'eventOutcome=', 1
+                        )[1].replace(', agentName=mediainfo', '').replace('\n', '')
+                        if 'eventDetail=Mediatrace' in log_entry:
+                            event_outcome = event_outcome.replace('mediainfo.xml', 'mediatrace.xml')
+                if (break_loop == 'continue') or (event_type == ''):
+                    continue
+                print event_type
+                event_row = [
+                    'UUID', ififuncs.create_uuid(),
+                    event_type, datetime, event_detail,
+                    '',
+                    event_outcome, '',
+                    event_outcome_detail_note, '',
+                    '', '',
+                    '', 'UUID',
+                    linking_object_identifier_value, ''
+                ]
+                ififuncs.append_csv('bla.csv', event_row)
+
+def make_events_csv():
+    '''
+    Generates a CSV with PREMIS-esque headings. Currently it's just called
+    'bla.csv' but it will probably be called:
+    UUID_premisevents.csv
+    and sit in the metadata directory.
+    '''
+    premis_events = [
+        'eventIdentifierType', 'eventIdentifierValue',
+        'eventType', 'eventDateTime', 'eventDetail',
+        'eventDetailExtension',
+        'eventOutcome',	'eventOutcomeDetail',
+        'eventOutcomeDetailNote', 'eventOutcomeDetailExtension',
+        'linkingAgentIdentifierType', 'linkingAgentIdentifierValue',
+        'linkingAgentIdentifierRole', 'linkingObjectIdentifierType',
+        'linkingObjectIdentifierValue', 'linkingObjectRole'
+    ]
+    ififuncs.create_csv('bla.csv', premis_events)
+
+def main():
+    '''
+    Launches all the other functions when run from the command line.
+    '''
+    logfile = sys.argv[1]
+    find_events(logfile)
+
+if __name__ == '__main__':
+    main()

--- a/premisobjects.py
+++ b/premisobjects.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+'''
+Creates a somewhat PREMIS compliant CSV file describing objects in a package.
+A seperate script will need to be written in order to transform these
+CSV files into XML.
+As the flat CSV structure prevents maintaining some of the complex
+relationships between units, some semantic units have been merged, for example:
+relation_structural_includes is really a combination of the
+relationshipType and relationshipSubType units, which each have the values:
+Structural and Includes respectively.
+
+todo:
+Document identifier assignment for files and IE. Probably in events sheet?
+Allow for derivation to be entered
+Link with events sheet
+Link mediainfo xml in /metadata to the objectCharacteristicsExtension field.
+
+
+Assumptions for now: representation UUID already exists as part of the
+SIP/AIP folder structure. Find a way to supply this, probably via argparse.
+'''
+
+import os
+import sys
+import ififuncs
+
+
+def get_checksum(manifest, filename):
+    '''
+    Extracts checksum from manifest, rather than generating a fresh one.
+    '''
+    if os.path.isfile(manifest):
+        with open(manifest, 'r') as manifest_object:
+            manifest_lines = manifest_object.readlines()
+            for md5 in manifest_lines:
+                if filename in md5:
+                    return md5[:32]
+
+
+def make_skeleton_csv():
+    '''
+    Generates a CSV with PREMIS-esque headings. Currently it's just called
+    'cle.csv' but it will probably be called:
+    UUID_premisobjects.csv
+    and sit in the metadata directory.
+    '''
+    premis_object_units = [
+        'objectIdentifier',
+        'objectCategory',
+        'messageDigestAlgorithm', 'messageDigest', 'messageDigestOriginator',
+        'size',	'formatName', 'formatVersion',
+        'objectCharacteristicsExtension', 'originalName',
+        'contentLocationType', 'contentLocationValue',
+        'relatedObjectIdentifierType', 'relatedObjectIdentifierValue',
+        'relatedObjectSequence',
+        'relatedEventIdentifierType', 'relatedEventIdentifierValue',
+        'relatedEventSequence',
+        'linkingEventIdentifierType', 'linkingEventIdentifierValue',
+        'relationship_structural_includes',
+        'relationship_structural_isincludedin',
+        'relationship_structural_represents',
+        'relationship_structural_hasroot',
+        'relationship_derivation_hassource'
+    ]
+    ififuncs.create_csv('cle.csv', premis_object_units)
+
+
+def file_description(source, manifest, representation_uuid):
+    '''
+    Generate PREMIS descriptions for items and write to CSV.
+    '''
+    item_ids = []
+    for root, _, filenames in os.walk(source):
+        if os.path.basename(root) == 'objects':
+            filenames = [f for f in filenames if f[0] != '.']
+            for item in filenames:
+                item_uuid = ififuncs.create_uuid()
+                full_path = os.path.join(root, item)
+                item_dictionary = {}
+                item_dictionary['objectIdentifier'] = ['UUID', item_uuid]
+                item_dictionary['objectCategory'] = 'file'
+                item_dictionary['size'] = str(os.path.getsize(full_path))
+                item_dictionary['originalName'] = item
+                item_dictionary['relationship_structural_isincludedin'] = representation_uuid
+                item_ids.append(item_uuid)
+                file_data = [
+                    item_dictionary['objectIdentifier'],
+                    item_dictionary['objectCategory'],
+                    'md5', get_checksum(manifest, item), 'internal',
+                    item_dictionary['size'], '', '',
+                    '', '',
+                    '', '',
+                    '', '',
+                    '',
+                    '', '',
+                    '',
+                    '', '',
+                    '',
+                    item_dictionary['relationship_structural_isincludedin'],
+                    '',
+                    '',
+                    ''
+                ]
+                ififuncs.append_csv('cle.csv', file_data)
+    return item_ids
+def representation_description(representation_uuid, item_ids):
+    '''
+    Generate PREMIS descriptions for a representation and write to CSV.
+    '''
+
+    representation_dictionary = {}
+    representation_dictionary['objectIdentifier'] = ['UUID', representation_uuid]
+    representation_dictionary['objectCategory'] = 'representation'
+    representation_dictionary['relationship_structural_includes'] = ''
+    for item_id in item_ids:
+        representation_dictionary['relationship_structural_includes'] += item_id + '|'
+    representation_data = [
+        representation_dictionary['objectIdentifier'],
+        representation_dictionary['objectCategory'],
+        '', '', '',
+        '', '', '',
+        '', '',
+        '', '',
+        '', '',
+        '',
+        '', '',
+        '',
+        '', '',
+        representation_dictionary['relationship_structural_includes'],
+        '',
+        '',
+        '',
+        ''
+    ]
+    ififuncs.append_csv('cle.csv', representation_data)
+
+
+def intellectual_entity_description():
+    '''
+    Generate PREMIS descriptions for Intellectual Entities and write to CSV.
+    '''
+    intellectual_entity_dictionary = {}
+    intellectual_entity_dictionary['objectIdentifier'] = ['UUID', ififuncs.create_uuid()]
+    intellectual_entity_dictionary['objectCategory'] = 'intellectual entity'
+    print intellectual_entity_dictionary
+def find_representation_uuid(source):
+    '''
+    This extracts the representation UUID from a directory name.
+    This should be moved to ififuncs as it can be used by other scripts.
+    '''
+    for root, _, _ in os.walk(source):
+        if 'objects' in root:
+            return os.path.basename(os.path.dirname(root))
+
+
+def main():
+    '''
+    Launches all the other functions when run from the command line.
+    '''
+    make_skeleton_csv()
+    source = sys.argv[1]
+    manifest = sys.argv[2]
+    representation_uuid = find_representation_uuid(source)
+    item_ids = file_description(source, manifest, representation_uuid)
+    #intellectual_entity_description()
+    representation_description(representation_uuid, item_ids)
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
Not ready to merge, but sending a pull request for visibility. I added a lot of information to the readme and to the docstrings within the functions, so here's a copypaste of the docstring output as generate by `pydoc`

```
Help on module premisobjects:

NAME
    premisobjects

FILE
    ifigit/ifiscripts/premisobjects.py

DESCRIPTION
    Creates a somewhat PREMIS compliant CSV file describing objects in a package.
    A seperate script will need to be written in order to transform these
    CSV files into XML.
    As the flat CSV structure prevents maintaining some of the complex
    relationships between units, some semantic units have been merged, for example:
    relation_structural_includes is really a combination of the
    relationshipType and relationshipSubType units, which each have the values:
    Structural and Includes respectively.
    
    todo:
    Document identifier assignment for files and IE. Probably in events sheet?
    Allow for derivation to be entered
    Link with events sheet
    Link mediainfo xml in /metadata to the objectCharacteristicsExtension field.
    
    
    Assumptions for now: representation UUID already exists as part of the
    SIP/AIP folder structure. Find a way to supply this, probably via argparse.

FUNCTIONS
    file_description(source, manifest, representation_uuid)
        Generate PREMIS descriptions for items and write to CSV.
    
    find_representation_uuid(source)
        This extracts the representation UUID from a directory name.
        This should be moved to ififuncs as it can be used by other scripts.
    
    get_checksum(manifest, filename)
        Extracts checksum from manifest, rather than generating a fresh one.
    
    intellectual_entity_description()
        Generate PREMIS descriptions for Intellectual Entities and write to CSV.
    
    main()
        Launches all the other functions when run from the command line.
    
    make_skeleton_csv()
        Generates a CSV with PREMIS-esque headings. Currently it's just called
        'cle.csv' but it will probably be called:
        UUID_premisobjects.csv
        and sit in the metadata directory.
    
    representation_description(representation_uuid, item_ids)
        Generate PREMIS descriptions for a representation and write to CSV.


```

```
Help on module premiscsv:

NAME
    premiscsv

FILE
    ifigit/ifiscripts/premiscsv.py

DESCRIPTION
    Extracts preservation events from an IFI plain text log file and converts
    to a CSV using the PREMIS data dictionary

FUNCTIONS
    find_events(logfile)
        A very hacky attempt to extract the relevant preservation events from our
        log files.
    
    main()
        Launches all the other functions when run from the command line.
    
    make_events_csv()
        Generates a CSV with PREMIS-esque headings. Currently it's just called
        'bla.csv' but it will probably be called:
        UUID_premisevents.csv
        and sit in the metadata directory.


```