### PR TITLE
seq2ffv1 - completely rewrites script to use sipcreator, attempt at #198

### DIFF
--- a/concat.py
+++ b/concat.py
@@ -217,8 +217,6 @@ def main(args_):
         log_name_source,
         'EVENT = eventType=modification, agentName=mkvpropedit, eventDetail=Chapters added to file detailing start point of source clips.')
     ififuncs.concat_textfile(video_files, concat_file)
-    with open(log_name_source, 'r') as concat_log:
-        concat_lines = concat_log.readlines()
     if not args.no_sip:
         sipcreator_log, sipcreator_manifest = sipcreator.main(['-i', output_file, '-u', uuid, '-oe', object_entry, '-user', user, '-o', args.o])
         shutil.move(fmd5_logfile, os.path.dirname(sipcreator_log))
@@ -226,14 +224,7 @@ def main(args_):
         logs_dir = os.path.dirname(sipcreator_log)
         ififuncs.manifest_update(sipcreator_manifest, os.path.join(logs_dir, os.path.basename(fmd5_logfile)))
         ififuncs.manifest_update(sipcreator_manifest, os.path.join(logs_dir,(os.path.basename(validation_logfile.replace('\\\\', '\\').replace('\:', ':')))))
-        with open(sipcreator_log, 'r') as sipcreator_log_object:
-            sipcreator_lines = sipcreator_log_object.readlines()
-        with open(sipcreator_log, 'wb') as fo:
-            for lines in concat_lines:
-                fo.write(lines)
-            for remaining_lines in sipcreator_lines:
-                fo.write(remaining_lines)
-        ififuncs.checksum_replace(sipcreator_manifest, sipcreator_log)
+        ififuncs.merge_logs(log_name_source, sipcreator_log, sipcreator_manifest)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/copyit.py
+++ b/copyit.py
@@ -135,9 +135,11 @@ def make_manifest(
                 checksum_list.append([root, files])
     elif os.path.isfile(manifest_dir):
         checksum_list = [[os.path.dirname(manifest_dir), os.path.basename(manifest_dir)]]
+    if len(checksum_list) == 1:
+        source_counter = 1
     for files in checksum_list:
         print 'Generating MD5 for %s - %d of %d' % (
-            files, counter2, source_counter
+            os.path.join(files[0], files[1]), counter2, source_counter
             )
         md5 = hashlib_md5(os.path.join(files[0], files[1]))
         root2 = files[0].replace(path_to_remove, '')
@@ -422,6 +424,9 @@ def count_stuff(source):
         for files in filenames:
             source_count += 1
             file_list.append(files)
+    if os.path.isfile(source):
+        if len(file_list) == 0:
+            source_count = 1
     return source_count, file_list
 
 

--- a/copyit.py
+++ b/copyit.py
@@ -356,6 +356,11 @@ def setup(args_):
         action='store_true',
         help='use gcp instead of rsync on osx for SPEED on LTO'
     )
+    parser.add_argument(
+        '-move',
+        action='store_true',
+        help='Move files instead of copying - much faster!'
+    )
     rootpos = ''
     dircheck = None
     args = parser.parse_args(args_)
@@ -620,10 +625,13 @@ def main(args_):
                 log_name_source,
                 'EVENT = File Transfer Overwrite - Destination directory already exists - Overwriting.'
             )
-        copy_dir(
-            source, destination_final_path,
-            log_name_source, rootpos, destination, dirname, args
-        )
+        if not args.move:
+            copy_dir(
+                source, destination_final_path,
+                log_name_source, rootpos, destination, dirname, args
+            )
+        else:
+            shutil.move(source, destination_final_path)
     else:
         generate_log(
             log_name_source,

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -487,7 +487,8 @@ def parse_image_sequence(images):
         ffmpeg_friendly_name = image_seq_without_container
     start_number_length = len(start_number)
     number_regex = "%0" + str(start_number_length) + 'd.'
-    root_filename = ffmpeg_friendly_name
+    # remove trailing underscore
+    root_filename = ffmpeg_friendly_name[:-1]
     ffmpeg_friendly_name += number_regex + '%s' % container
     return ffmpeg_friendly_name, start_number, root_filename
 

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -850,3 +850,20 @@ def read_lines(infile):
     '''
     for lineno, line in enumerate(infile):
         yield lineno, line
+
+
+def merge_logs(log_name_source, sipcreator_log, sipcreator_manifest):
+    '''
+    merges the contents of one log with another.
+    updates checksums in your manifest.
+    '''
+    with open(log_name_source, 'r') as concat_log:
+        concat_lines = concat_log.readlines()
+    with open(sipcreator_log, 'r') as sipcreator_log_object:
+        sipcreator_lines = sipcreator_log_object.readlines()
+    with open(sipcreator_log, 'wb') as fo:
+        for lines in concat_lines:
+            fo.write(lines)
+        for remaining_lines in sipcreator_lines:
+            fo.write(remaining_lines)
+    checksum_replace(sipcreator_manifest, sipcreator_log)

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -139,6 +139,7 @@ def make_ffv1(
         '-u',
         uuid,
         '-quiet',
+        '-move',
         '-user',
         'Kieran',
         '-oe',

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -57,7 +57,7 @@ def run_loop(args):
         (ffmpeg_friendly_name,
          start_number, root_filename) = ififuncs.parse_image_sequence(images)
         source_abspath = os.path.join(source_directory, ffmpeg_friendly_name)
-        judgement = make_ffv1(
+        judgement, sipcreator_log, sipcreator_manifest = make_ffv1(
             start_number,
             source_abspath,
             output_dirname,
@@ -68,7 +68,8 @@ def run_loop(args):
         verdicts.append([root_filename, judgement])
         for verdict in verdicts:
             print "%-*s   : %s" % (50, verdict[0], verdict[1])
-    ififuncs.generate_log(log_name_source, 'seq2ffv1.py started.')
+    ififuncs.generate_log(log_name_source, 'seq2ffv1.py finished.')
+    ififuncs.merge_logs(log_name_source, sipcreator_log, sipcreator_manifest)
 
 
 def verify_losslessness(source_textfile, ffv1_md5):
@@ -210,7 +211,7 @@ def make_ffv1(
                     sipcreator_manifest,
                     os.path.join(metadata_dir, os.path.basename(files))
                 )
-        return judgement
+        return judgement, sipcreator_log, sipcreator_manifest
 
 def setup():
     '''

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -103,6 +103,7 @@ def make_ffv1(
     This launches the image sequence to FFV1/Matroska process
     as well as framemd5 losslessness verification.
     '''
+    uuid = ififuncs.create_uuid()
     if not args.no_sip:
         object_entry = ififuncs.get_object_entry()
     files_to_move = []
@@ -113,14 +114,14 @@ def make_ffv1(
     temp_dir = tempfile.gettempdir()
     logfile = os.path.join(
         temp_dir,
-        '%s_ffv1_transcode.log' % root_filename
+        '%s_ffv1_transcode.log' % uuid
     )
     files_to_move.append(logfile)
     logfile = "\'" + logfile + "\'"
     env_dict = ififuncs.set_environment(logfile)
-    ffv1_path = os.path.join(output_dirname, root_filename + '.mkv')
+    ffv1_path = os.path.join(output_dirname, uuid + '.mkv')
     source_textfile = os.path.join(
-        temp_dir, root_filename + 'source.framemd5'
+        temp_dir, uuid + '_source.framemd5'
     )
     files_to_move.append(source_textfile)
     ififuncs.generate_log(
@@ -151,7 +152,7 @@ def make_ffv1(
     subprocess.call(ffv12dpx, env=env_dict)
     ffv1_md5 = os.path.join(
         temp_dir,
-        root_filename + 'ffv1.framemd5'
+        uuid + '_ffv1.framemd5'
     )
     files_to_move.append(ffv1_md5)
     ififuncs.generate_log(
@@ -159,14 +160,14 @@ def make_ffv1(
         'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image'
     )
     ffv1_fmd5_cmd = [
-        'ffmpeg',
+        'ffmpeg', '-report',
         '-i', ffv1_path,
         '-pix_fmt', pix_fmt,
         '-f', 'framemd5',
         ffv1_md5
     ]
     ffv1_fmd5_logfile = os.path.join(
-        temp_dir, '%s_ffv1_framemd5.log' % root_filename
+        temp_dir, '%s_ffv1_framemd5.log' % uuid
     )
     files_to_move.append(ffv1_fmd5_logfile)
     ffv1_fmd5_logfile = "\'" + ffv1_fmd5_logfile + "\'"
@@ -180,7 +181,6 @@ def make_ffv1(
     if args.no_sip:
         return judgement
     else:
-        uuid = ififuncs.create_uuid()
         sip_dir = os.path.join(
             os.path.dirname(ffv1_path), os.path.join(object_entry, uuid)
         )

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -59,9 +59,9 @@ def verify_losslessness(source_textfile, ffv1_md5):
     with open(source_textfile) as source_md5_object:
         with open(ffv1_md5) as ffv1_md5_object:
             for (line1), (line2) in itertools.izip(
-                ififuncs.read_lines(
-                    source_md5_object
-                ), ififuncs.read_lines(ffv1_md5_object)
+                    ififuncs.read_lines(
+                        source_md5_object
+                    ), ififuncs.read_lines(ffv1_md5_object)
             ):
                 if line1 != line2:
                     if 'sar' in line1:
@@ -179,10 +179,10 @@ def setup():
     Sets up a lot of the variables and filepaths.
     '''
     parser = argparse.ArgumentParser(description='Transcode all DPX or TIFF'
-                                    ' image sequence in the subfolders of your'
-                                    ' source directory to FFV1 Version 3'
-                                    ' in a Matroska Container.'
-                                    ' Written by Kieran O\'Leary.')
+                                     ' image sequence in the subfolders of your'
+                                     ' source directory to FFV1 Version 3'
+                                     ' in a Matroska Container.'
+                                     ' Written by Kieran O\'Leary.')
     parser.add_argument(
         'source_directory',
         help='Input directory'

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -138,6 +138,7 @@ def make_ffv1(
         ffv1_path,
         '-u',
         uuid,
+        '-quiet',
         '-user',
         'Kieran',
         '-oe',

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -18,181 +18,85 @@ Generate CSV log that will be saved to your desktop
 import subprocess
 import os
 import argparse
-import datetime
-import time
 import itertools
+import tempfile
+import shutil
 import ififuncs
-from ififuncs import diff_textfiles
-from ififuncs import get_mediainfo
-from ififuncs import create_csv
-from ififuncs import append_csv
-from ififuncs import get_image_sequence_files
-from ififuncs import get_ffmpeg_friendly_name
+import sipcreator
 
-
-
-def read_lines(infile):
+def run_loop(args):
     '''
-    Returns line number and text from an textfile.
+    Launches a recursive loop to process all images sequences in your
+    subdirectories.
     '''
-    for lineno, line in enumerate(infile):
-        yield lineno, line
-
-
-def make_framemd5(directory, log_filename_alteration, args):
-    '''
-    Apparently this makes framemd5s. But it clearly does a lot more.
-    '''
-    (
-    basename,
-    ffmpeg_friendly_name,
-    start_number,
-    images,
-    container,
-    output_dirname) = make_folder_structure(directory, args)
-    output = output_dirname + '/metadata/%ssource.framemd5' % (basename)
-    logfile = output_dirname + '/logs/%s%s.log' % (
-        basename,
-        log_filename_alteration
-    )
-    logfile = "\'" + logfile + "\'"
-    env_dict = ififuncs.set_environment(logfile)
-    image_seq_without_container = ffmpeg_friendly_name
-    start_number_length = len(start_number)
-    number_regex = "%0" + str(start_number_length) + 'd.'
-    if len(images[0].split("_")[-1].split(".")) > 2:
-        image_seq_without_container = ffmpeg_friendly_name[:-1] + ffmpeg_friendly_name[-1].replace('_', '.')
-        ffmpeg_friendly_name = image_seq_without_container
-    ffmpeg_friendly_name += number_regex + '%s' % container
-    framemd5 = [
-        'ffmpeg', '-start_number',
-        start_number, '-report',
-        '-f', 'image2',
-        '-framerate', '24',
-        '-i', ffmpeg_friendly_name,
-        '-f', 'framemd5', output
-    ]
-    print framemd5
-    subprocess.call(framemd5, env=env_dict)
-    info = [
-        output_dirname,
-        output,
-        image_seq_without_container,
-        start_number,
-        container,
-        ffmpeg_friendly_name,
-        number_regex,
-        len(images)
-    ]
-    return info
-
-def remove_bad_files(root_dir):
-    '''
-    removes unwanted files. unless something is altered, just use the ififuncs
-    function instead.
-    '''
-    rm_these = ['.DS_Store', 'Thumbs.db', 'desktop.ini']
-    for root, _, files in os.walk(root_dir):
-        for name in files:
-            path = os.path.join(root, name)
-            for i in rm_these:
-                if name == i:
-                    print '***********************' + 'removing: ' + path
-                    os.remove(path)
-
-def setup():
-    '''
-    Sets up a lot of the variables and filepaths.
-    '''
-    csv_report_filename = os.path.join(
-        os.path.expanduser("~/Desktop/"),
-        'dpx_transcode_report' + time.strftime("_%Y_%m_%dT%H_%M_%S") + '.csv'
-    )
-    parser = argparse.ArgumentParser(description='Transcode all DPX or TIFF'
-                                    ' image sequence in the subfolders of your'
-                                    ' source directory to FFV1 Version 3'
-                                    ' in a Matroska Container.'
-                                    'CSV report is generated on your desktop.'
-                                    ' Written by Kieran O\'Leary.')
-    parser.add_argument('source_directory', help='Input directory')
-    parser.add_argument('destination', help='Destination directory')
-    args = parser.parse_args()
-    create_csv(csv_report_filename, (
-        'Sequence Name', 'Lossless?',
-        'Start time', 'Finish Time',
-        'Transcode Start Time', 'Transcode Finish Time',
-        'Transcode Time', 'Frame Count',
-        'Encode FPS', 'Sequence Size',
-        'FFV1 Size', 'Pixel Format',
-        'Sequence Type', 'Width',
-        'Height', 'Compression Ratio'
-        ))
-    return args, csv_report_filename
-
-
-def make_folder_structure(directory, args):
-    '''
-    Creates output folder structure and sets more variables
-    '''
-    images = get_image_sequence_files(directory)
-    if images == 'none':
-        return 'none'
-    (ffmpeg_friendly_name,
-    container,
-    start_number) = get_ffmpeg_friendly_name(images)
-    output_parent_directory = args.destination
-    if start_number == '864000':
-        output_dirname = os.path.join(
-            output_parent_directory,
-            os.path.basename(directory) + time.strftime("%Y_%m_%dT%H_%M_%S")
-        )
-        basename = os.path.basename(directory)
-    else:
-        output_dirname = os.path.join(
-            output_parent_directory,
-            ffmpeg_friendly_name + time.strftime("%Y_%m_%dT%H_%M_%S")
-        )
-        basename = ffmpeg_friendly_name
-    logs_dir = output_dirname + '/logs'
-    objects_dir = output_dirname + '/objects'
-    metadata_dir = output_dirname + '/metadata'
-    try:
-        os.makedirs(output_dirname)
-        os.makedirs(logs_dir)
-        os.makedirs(objects_dir)
-        os.makedirs(metadata_dir)
-    except OSError:
-        print 'directories already exist'
-    return (basename,
-            ffmpeg_friendly_name,
+    for source_directory, _, _ in os.walk(args.source_directory):
+        output_dirname = args.destination
+        images = ififuncs.get_image_sequence_files(source_directory)
+        (ffmpeg_friendly_name,
+         start_number, root_filename) = ififuncs.parse_image_sequence(images)
+        source_abspath = os.path.join(source_directory, ffmpeg_friendly_name)
+        make_ffv1(
             start_number,
-            images,
-            container,
-            output_dirname)
+            source_abspath,
+            output_dirname,
+            root_filename,
+        )
+
+
+def verify_losslessness(source_textfile, ffv1_md5):
+    '''
+    Compares two framemd5 documents in order to determine losslessness.
+    '''
+    ififuncs.diff_textfiles(source_textfile, ffv1_md5)
+    checksum_mismatches = []
+    with open(source_textfile) as source_md5_object:
+        with open(ffv1_md5) as ffv1_md5_object:
+            for (line1), (line2) in itertools.izip(
+                ififuncs.read_lines(
+                    source_md5_object
+                ), ififuncs.read_lines(ffv1_md5_object)
+            ):
+                if line1 != line2:
+                    if 'sar' in line1:
+                        checksum_mismatches = ['sar']
+                    else:
+                        checksum_mismatches.append(1)
 
 def make_ffv1(
         start_number,
-        dpx_filename,
+        source_abspath,
         output_dirname,
-        output_filename,
-        image_seq_without_container,
-        env_dict
+        root_filename,
     ):
     '''
     This launches the image sequence to FFV1/Matroska process
     as well as framemd5 losslessness verification.
     '''
-
+    object_entry = ififuncs.get_object_entry()
+    files_to_move = []
     pix_fmt = ififuncs.img_seq_pixfmt(
         start_number,
-        os.path.abspath(dpx_filename)
+        source_abspath
     )
+    temp_dir = tempfile.gettempdir()
+    logfile = os.path.join(
+        temp_dir,
+        '%s_ffv1_transcode.log' % root_filename
+    )
+    files_to_move.append(logfile)
+    logfile = "\'" + logfile + "\'"
+    env_dict = ififuncs.set_environment(logfile)
+    ffv1_path = os.path.join(output_dirname, root_filename + '.mkv')
+    source_textfile = os.path.join(
+        temp_dir, root_filename + 'source.framemd5'
+    )
+    files_to_move.append(source_textfile)
     ffv12dpx = [
         'ffmpeg', '-report',
         '-f', 'image2',
         '-framerate', '24',
         '-start_number', start_number,
-        '-i', os.path.abspath(dpx_filename),
+        '-i', source_abspath,
         '-strict', '-2',
         '-c:v', 'ffv1',
         '-level', '3',
@@ -200,22 +104,16 @@ def make_ffv1(
         '-slicecrc', '1',
         '-slices', '16',
         '-pix_fmt', pix_fmt,
-        output_dirname +  '/objects/' + output_filename + '.mkv'
+        ffv1_path,
+        '-f', 'framemd5', source_textfile
     ]
     print ffv12dpx
-    transcode_start = datetime.datetime.now()
-    transcode_start_machine = time.time()
     subprocess.call(ffv12dpx, env=env_dict)
-    transcode_finish = datetime.datetime.now()
-    transcode_finish_machine = time.time()
-    transcode_time = transcode_finish_machine - transcode_start_machine
-    ffv1_path = output_dirname +  '/objects/'  + output_filename + '.mkv'
-    width = get_mediainfo('duration', '--inform=Video;%Width%', ffv1_path)
-    height = get_mediainfo('duration', '--inform=Video;%Height%', ffv1_path)
     ffv1_md5 = os.path.join(
-        output_dirname +  '/metadata',
-        image_seq_without_container + 'ffv1.framemd5'
+        temp_dir,
+        root_filename + 'ffv1.framemd5'
     )
+    files_to_move.append(ffv1_md5)
     ffv1_fmd5_cmd = [
         'ffmpeg',
         '-i', ffv1_path,
@@ -224,154 +122,65 @@ def make_ffv1(
         ffv1_md5
     ]
     ffv1_fmd5_logfile = os.path.join(
-        output_dirname, 'logs/%s_ffv1_framemd5.log' % output_filename
+        temp_dir, '%s_ffv1_framemd5.log' % root_filename
     )
+    files_to_move.append(ffv1_fmd5_logfile)
     ffv1_fmd5_logfile = "\'" + ffv1_fmd5_logfile + "\'"
     ffv1_fmd5_env_dict = ififuncs.set_environment(ffv1_fmd5_logfile)
     subprocess.call(ffv1_fmd5_cmd, env=ffv1_fmd5_env_dict)
-    finish = datetime.datetime.now()
-    return (
-        ffv1_path, ffv1_md5,
-        transcode_time, pix_fmt,
-        width, height,
-        finish, transcode_start,
-        transcode_finish
+    verify_losslessness(source_textfile, ffv1_md5)
+    uuid = ififuncs.create_uuid()
+    sip_dir = os.path.join(
+        os.path.dirname(ffv1_path), os.path.join(object_entry, uuid)
     )
-
-def run_loop(args, csv_report_filename):
-    '''
-    Launches a recursive loop to process all images sequences in your
-    subdirectories.
-    '''
-    for root, _, filenames in os.walk(args.source_directory):
-        source_directory = root
-        total_size = 0
-        start = datetime.datetime.now()
-        info = make_framemd5(source_directory, 'dpx_framemd5', args)
-        if info == 'none':
-            continue
-        for files in filenames:
-            total_size += os.path.getsize(os.path.join(root, files))
-        output_dirname = info[0]
-        source_textfile = info[1]
-        image_seq_without_container = info[2]
-        start_number = info[3]
-        container = info[4]
-        dpx_filename = info[5]
-        sequence_length = info[7]
-        output_filename = image_seq_without_container[:-1]
-        logfile = os.path.join(
-            output_dirname,
-            'logs/%s_ffv1_transcode.log' % output_filename
-        )
-        logfile = "\'" + logfile + "\'"
-        (ffv1_path,
-         ffv1_md5,
-         transcode_time,
-         pix_fmt,
-         width,
-         height,
-         finish,
-         transcode_start,
-         transcode_finish) = make_ffv1(
-            start_number,
-            dpx_filename,
-            output_dirname,
-            output_filename,
-            image_seq_without_container,
-            ififuncs.set_environment(logfile)
-        )
-        comp_ratio = float(total_size) / float(os.path.getsize(ffv1_path))
-        judgement = diff_textfiles(source_textfile, ffv1_md5)
-        fps = float(sequence_length) / float(transcode_time)
-        checksum_mismatches = []
-        with open(source_textfile) as source_md5_object:
-            with open(ffv1_md5) as ffv1_md5_object:
-                for (line1), (line2) in itertools.izip(
-                    read_lines(source_md5_object), read_lines(ffv1_md5_object)
-                ):
-                    if line1 != line2:
-                        if 'sar' in line1:
-                            checksum_mismatches = ['sar']
-                        else:
-                            checksum_mismatches.append(1)
-        log_results(
-            checksum_mismatches,
-            csv_report_filename,
-            os.path.basename(output_dirname),
-            judgement,
-            start, finish,
-            transcode_start, transcode_finish,
-            transcode_time, sequence_length,
-            fps, total_size,
-            os.path.getsize(ffv1_path), pix_fmt,
-            container, width,
-            height, comp_ratio)
-
-
-def log_results(
-    checksum_mismatches,
-    csv_report_filename,
-    parent_basename,
-    judgement,
-    start, finish,
-    transcode_start, transcode_finish,
-    transcode_time, sequence_length,
-    fps, total_size,
-    ffv1_size, pix_fmt,
-    container, width,
-    height, comp_ratio
-):
-    if len(checksum_mismatches) == 0:
-        print 'LOSSLESS'
-        append_csv(
-            csv_report_filename, (
-                parent_basename, judgement,
-                start, finish,
-                transcode_start, transcode_finish,
-                transcode_time, sequence_length,
-                fps, total_size,
-                ffv1_size, pix_fmt,
-                container, width,
-                height, comp_ratio
+    sipcreator_log, sipcreator_manifest = sipcreator.main([
+        '-i',
+        ffv1_path,
+        '-u',
+        uuid,
+        '-user',
+        'Kieran',
+        '-oe',
+        object_entry,
+        '-o', os.path.dirname(ffv1_path)])
+    logs_dir = os.path.join(sip_dir, 'logs')
+    metadata_dir = os.path.join(sip_dir, 'metadata')
+    for files in files_to_move:
+        if files.endswith('.log'):
+            shutil.move(files, logs_dir)
+            ififuncs.manifest_update(
+                sipcreator_manifest,
+                os.path.join(logs_dir, os.path.basename(files))
             )
-        )
-
-    elif len(checksum_mismatches) == 1:
-        if checksum_mismatches[0] == 'sar':
-            print 'Image content is lossless, Pixel Aspect Ratio has been altered - This is mostly likely because your source had no pixel aspect ratio information, and Matroska is specifying 1:1. https://www.ietf.org/mail-archive/web/cellar/current/msg00739.html '
-            append_csv(csv_report_filename, (
-                parent_basename, 'LOSSLESS - different PAR',
-                start, finish, transcode_start,
-                transcode_finish, transcode_time,
-                sequence_length, fps,
-                total_size, ffv1_size,
-                pix_fmt, container,
-                width, height,
-                comp_ratio
+        elif files.endswith('.framemd5'):
+            shutil.move(files, metadata_dir)
+            ififuncs.manifest_update(
+                sipcreator_manifest,
+                os.path.join(metadata_dir, os.path.basename(files))
             )
-                      )
-    elif len(checksum_mismatches) > 1:
-        print 'NOT LOSSLESS'
-        append_csv(csv_report_filename, (
-            parent_basename, judgement,
-            start, finish, transcode_start,
-            transcode_finish, transcode_time,
-            sequence_length, fps,
-            total_size, ffv1_size,
-            pix_fmt, container,
-            width, height,
-            comp_ratio
-        ))
+    return source_textfile, ffv1_md5
 
+def setup():
+    '''
+    Sets up a lot of the variables and filepaths.
+    '''
+    parser = argparse.ArgumentParser(description='Transcode all DPX or TIFF'
+                                    ' image sequence in the subfolders of your'
+                                    ' source directory to FFV1 Version 3'
+                                    ' in a Matroska Container.'
+                                    ' Written by Kieran O\'Leary.')
+    parser.add_argument('source_directory', help='Input directory')
+    parser.add_argument('destination', help='Destination directory')
+    args = parser.parse_args()
+    return args
 
 def main():
     '''
     Overly long main function that does most of the heavy lifting.
     This needs to be broken up into smaller functions.
     '''
-    args, csv_report_filename = setup()
-    run_loop(args, csv_report_filename)
+    args = setup()
+    run_loop(args)
 
 
 if __name__ == '__main__':

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -87,13 +87,16 @@ def consolidate_logs(lognames, path):
                 log_object.write(lines)
 
 
-def move_files(inputs, sip_path):
+def move_files(inputs, sip_path, args):
     '''
     Runs moveit.py on all inputs
     '''
     log_names = []
     for item in inputs:
-        log_name = copyit.main([item, os.path.join(sip_path, 'objects')])
+        cmd = [item, os.path.join(sip_path, 'objects')]
+        if args.move:
+            cmd.append('-move')
+        log_name = copyit.main(cmd)
         log_names.append(log_name)
     consolidate_logs(log_names, sip_path)
     return log_names
@@ -160,6 +163,10 @@ def parse_args(args_):
     parser.add_argument(
         '-quiet', action='store_true',
         help='Quiet mode, suppresses the analyze_logs() report'
+    )
+    parser.add_argument(
+        '-move', action='store_true',
+        help='invokes the -move argument in copyit.py - moves instead of copy.'
     )
     parser.add_argument(
         '-oe',
@@ -310,7 +317,7 @@ def main(args_):
     ) 
     metadata_dir = os.path.join(sip_path, 'metadata')
     logs_dir = os.path.join(sip_path, 'logs')
-    log_names = move_files(inputs, sip_path)
+    log_names = move_files(inputs, sip_path, args)
     get_metadata(sip_path, new_log_textfile)
     ififuncs.hashlib_manifest(
         metadata_dir, metadata_dir + '/metadata_manifest.md5', metadata_dir

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -158,6 +158,10 @@ def parse_args(args_):
         help='Adds DCP specific processing, like creating objects subfolder with text extracted from <ContentTitleText> in the CPL.'
     )
     parser.add_argument(
+        '-quiet', action='store_true',
+        help='Quiet mode, suppresses the analyze_logs() report'
+    )
+    parser.add_argument(
         '-oe',
         help='Enter the Object Entry number for the representation.SIP will be placed in a folder with this name.'
     )
@@ -318,7 +322,8 @@ def main(args_):
         os.path.dirname(os.path.dirname(logs_dir))
     )
     ififuncs.sort_manifest(new_manifest_textfile)
-    log_report(log_names)
+    if not args.quiet:
+        log_report(log_names)
     finish = datetime.datetime.now()
     print '\n', user, 'ran this script at %s and it finished at %s' % (start, finish)
     if args.d:


### PR DESCRIPTION
Attempts to fix #198, but using seq2ffv1 instead of makeffv1 as a proof of concept. Functionally, this produces similar packages to the original seq2ffv1, except it uses sipcreator.py instead.
This also removes the CSV report for benchmarking.

A general losslessness report should be added somewhere, maybe mimicing masscopy. Filenames have trailing characters too, but overall, this should be an improvement.