### PR TITLE
Sipcheck

### DIFF
--- a/copyit.py
+++ b/copyit.py
@@ -329,8 +329,9 @@ def check_for_sip(args):
     '''
     remove_bad_files(args, None)
     for filenames in os.listdir(args):
+        # make sure that it's an IFI SIP.
         if 'manifest.md5' in filenames:
-            if len(os.listdir(args)) == 1:
+            if len(os.listdir(args)) == 2:
                 dircheck = filenames.replace('_manifest.md5', '')
                 if os.path.isdir(os.path.join(args, dircheck)):
                     print 'ifi sip found'

--- a/copyit.py
+++ b/copyit.py
@@ -328,10 +328,11 @@ def check_for_sip(args):
     '''
     for filenames in os.listdir(args):
         if 'manifest.md5' in filenames:
-            dircheck = filenames.replace('_manifest.md5', '')
-            if os.path.isdir(os.path.join(args, dircheck)):
-                print 'ifi sip found'
-                return os.path.join(args, dircheck)
+            if len(os.listdir(args)) == 1:
+                dircheck = filenames.replace('_manifest.md5', '')
+                if os.path.isdir(os.path.join(args, dircheck)):
+                    print 'ifi sip found'
+                    return os.path.join(args, dircheck)
 
 
 def setup(args_):

--- a/copyit.py
+++ b/copyit.py
@@ -79,10 +79,11 @@ def remove_bad_files(root_dir, log_name_source):
             for i in rm_these:
                 if name == i:
                     print '***********************' + 'removing: ' + path
-                    generate_log(
-                        log_name_source,
-                        'EVENT = Unwanted file removal - %s was removed' % path
-                    )
+                    if not log_name_source == None:
+                        generate_log(
+                            log_name_source,
+                            'EVENT = Unwanted file removal - %s was removed' % path
+                        )
                     try:
                         os.remove(path)
                     except OSError:
@@ -326,6 +327,7 @@ def check_for_sip(args):
     This checks if the input folder contains the actual payload, eg:
     the UUID folder(containing logs/metadata/objects) and the manifest sidecar.
     '''
+    remove_bad_files(args, None)
     for filenames in os.listdir(args):
         if 'manifest.md5' in filenames:
             if len(os.listdir(args)) == 1:


### PR DESCRIPTION
So this fixes some issues where copyit did not transfer all files in a folder. This usually happened if you if your source folder contained another folder that had a manifest sidecar, as well as other files. Only the folder with the manifest sidecar would be copied, not the other files.
This inhibited use of copyit.