### PR TITLE
Rearrange files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ table of contents
     * [batchaccession.py](https://github.com/kieranjol/IFIscripts#batchaccessionpy)
     * [order.py](https://github.com/kieranjol/IFIscripts#orderpy)
     * [makepbcore.py](https://github.com/kieranjol/IFIscripts#makepbcorepy)
-    * [deletefiles.py](https://github.com/kieranjol/IFIscripts#deletefiles)
+    * [deletefiles.py](https://github.com/kieranjol/IFIscripts#deletefilespy)
+    * [rearrange.py](https://github.com/kieranjol/IFIscripts#rearrangepy)
 1. [Transcodes](https://github.com/kieranjol/IFIscripts#transcodes)
     * [makeffv1.py](https://github.com/kieranjol/IFIscripts#makeffv1py)
     * [bitc.py](https://github.com/kieranjol/IFIscripts#bitcpy)
@@ -109,11 +110,19 @@ NOTE: `Objects.py` has been copied from https://github.com/simsong/dfxml. `walk_
 * Run `makepbcore.py -h` for all options.
 
 ### deletefiles.py ###
-* Deletes files after sipcreator has been run, but before accession.py has been run.
+* Deletes files after `sipcreator.py` has been run, but before `accession.py` has been run.
 * Manifests are updated, metadata is deleted and the events are all logged in the logfile.
 * This script takes the parent OE folder as input. Use the `-i` argument to supply the various files that should be deleted from the package.
 * Usage for deleting two example files - `deletefiles.py /path/to/oe_folder -i path/to/file1.mov path/to/file2.mov`
 * Run `deletefiles.py -h` for all options.
+
+### rearrange.py ###
+* Rearranges files into a subfolder files after `sipcreator.py` has been run, but before `accession.py` has been run.
+* Manifests are updated, files are moved, and the events are all logged in the logfile.
+* This is useful in conjunction with `sipcreator.py` and `deletefiles.py`, in case a user wishes to impose a different ordering of the files within a large package. For example, from a folder with 1000 photographs, you may wish to create some sufolders to reflect different series/subseries within this collection. This script will track all these arrangement decisions.
+* This script takes the parent OE folder as input. Use the `-i` argument to supply the various files that should be moved. The `new_folder` argument declares which folder the files should be moved into. Run `validate.py` to verify that all went well.
+* Usage for moving a single file into a subfolder - `rearrange.py /path/to/oe_folder -i path/to/uuid/objects/file1.mov -new_folder path/to/uuid/objects/new_foldername`
+* Run `rearrange.py -h` for all options.
 
 ## Transcodes ##
 

--- a/rearrange.py
+++ b/rearrange.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+'''
+Moves files into subfolders, updates logfiles and manifests.
+'''
+import os
+import argparse
+import sys
+import datetime
+import shutil
+import ififuncs
+
+
+def parse_args(args_):
+    '''
+    Parse command line arguments.
+    '''
+    parser = argparse.ArgumentParser(
+        description='Moves files into subfolders, updates logfiles and manifests.'
+        ' Written by Kieran O\'Leary.'
+    )
+    parser.add_argument(
+        '-i', nargs='+',
+        help='full path of files to be moved', required=True
+    )
+    parser.add_argument(
+        '-new_folder',
+        help='full path of the new destination folder', required=True
+    )
+    parser.add_argument(
+        'input',
+        help='full path of \'sipcreator\' Object Entry package'
+    )
+    parser.add_argument(
+        '-user',
+        help='Declare who you are. If this is not set, you will be prompted.')
+    parsed_args = parser.parse_args(args_)
+    return parsed_args
+
+
+def update_manifest(manifest, old_path, new_path, new_log_textfile):
+    '''
+    Updates the path in a checksum manifest to reflect the new location.
+    '''
+    updated_lines = []
+    with open(manifest, 'r') as file_object:
+        checksums = file_object.readlines()
+        for line in checksums:
+            if old_path in line:
+                line = line.replace(old_path, new_path)
+                print 'the following path: %s has been updated with %s in the package manifest' % (old_path, new_path)
+                ififuncs.generate_log(
+                    new_log_textfile,
+                    'EVENT = eventType=metadata modification,'
+                    ' agentName=rearrange.py,'
+                    ' eventDetail=the following path: %s has been updated with %s in the package manifest' % (old_path, new_path)
+                )
+                updated_lines.append(line)
+            else:
+                updated_lines.append(line)
+    with open(manifest, 'w') as updated_manifest:
+        for updated_line in updated_lines:
+            updated_manifest.write(updated_line)
+
+
+def main(args_):
+    '''
+    Launch all the functions for creating an IFI SIP.
+    '''
+    args = parse_args(args_)
+    source = args.input
+    sip_path = ififuncs.check_for_sip([source])
+    if sip_path is not None:
+        oe_path = os.path.dirname(sip_path)
+        uuid = os.path.basename(sip_path)
+        sip_manifest = os.path.join(
+            oe_path, uuid
+            ) + '_manifest.md5'
+    start = datetime.datetime.now()
+    print args
+    if args.user:
+        user = args.user
+    else:
+        user = ififuncs.get_user()
+    new_log_textfile = os.path.join(sip_path, 'logs' + '/' + uuid + '_sip_log.log')
+    ififuncs.generate_log(
+        new_log_textfile,
+        'EVENT = rearrange.py started'
+    )
+    ififuncs.generate_log(
+        new_log_textfile,
+        'eventDetail=rearrange.py %s' % ififuncs.get_script_version('rearrange.py')
+    )
+    ififuncs.generate_log(
+        new_log_textfile,
+        'Command line arguments: %s' % args
+    )
+    ififuncs.generate_log(
+        new_log_textfile,
+        'EVENT = agentName=%s' % user
+    )
+    if not os.path.isdir(args.new_folder):
+        os.makedirs(args.new_folder)
+    for filename in args.i:
+        # add test to see if it actually deleted - what if read only?
+        shutil.move(filename, args.new_folder)
+        print '%s has been moved into %s' % (filename, args.new_folder)
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = eventType=file movement,'
+            ' eventOutcomeDetailNote=%s has been moved into %s'
+            ' agentName=shutil.move()'
+            % (filename, args.new_folder)
+        )
+        relative_filename = filename.replace(args.input + '/', '')
+        relative_new_folder = args.new_folder.replace(args.input + '/', '')
+        update_manifest(
+            sip_manifest,
+            relative_filename,
+            os.path.join(relative_new_folder, os.path.basename(relative_filename)),
+            new_log_textfile
+        )
+    ififuncs.generate_log(
+        new_log_textfile,
+        'EVENT = rearrange.py finished'
+    )
+    ififuncs.checksum_replace(sip_manifest, new_log_textfile, 'md5')
+    finish = datetime.datetime.now()
+    print '\n', user, 'ran this script at %s and it finished at %s' % (start, finish)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
This is most useful for special collections and personal archiving workflows. It allows further appraisal and rearrangement to happen after the Object Entry phase, but before accessioning.

From the readme:

### rearrange.py ###
* Rearranges files into a subfolder files after `sipcreator.py` has been run, but before `accession.py` has been run.
* Manifests are updated, files are moved, and the events are all logged in the logfile.
* This is useful in conjunction with `sipcreator.py` and `deletefiles.py`, in case a user wishes to impose a different ordering of the files within a large package. For example, from a folder with 1000 photographs, you may wish to create some sufolders to reflect different series/subseries within this collection. This script will track all these arrangement decisions.
* This script takes the parent OE folder as input. Use the `-i` argument to supply the various files that should be moved. The `new_folder` argument declares which folder the files should be moved into. Run `validate.py` to verify that all went well.
* Usage for moving a single file into a subfolder - `rearrange.py /path/to/oe_folder -i path/to/uuid/objects/file1.mov -new_folder path/to/uuid/objects/new_foldername`
* Run `rearrange.py -h` for all options.
