### PR TITLE
Batchaccession order

### DIFF
--- a/batchaccession.py
+++ b/batchaccession.py
@@ -14,11 +14,27 @@ import argparse
 import sys
 import csv
 import os
+import re
 import time
 import ififuncs
 import accession
 import copyit
 import order
+
+'''
+the following two functions for natural sorting are stolen from
+https://stackoverflow.com/questions/5967500/how-to-correctly-sort-a-string-with-a-number-inside?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+'''
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+def natural_keys(text):
+    '''
+    alist.sort(key=natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    '''
+    return [ atoi(c) for c in re.split('(\d+)', text) ]
 
 
 def gather_metadata(source):
@@ -212,7 +228,7 @@ def main(args_):
         'Do you want to proceed?'
     )
     if proceed == 'Y':
-        for package in sorted(to_accession.keys()):
+        for package in sorted(to_accession.keys(), key=natural_keys):
             accession_cmd = [
                 package, '-user', user,
                 '-pbcore', '-f',

--- a/batchaccession.py
+++ b/batchaccession.py
@@ -58,36 +58,40 @@ def initial_check(args, accession_digits, oe_list, reference_number):
     # accession = 'af' + str(accession_digits)
     ref = reference_number
     reference_digits = int(ref[2:])
-    for root, _, _ in sorted(os.walk(args.input)):
-        if os.path.basename(root)[:2] == 'oe' and len(os.path.basename(root)[2:]) >= 4:
-            if copyit.check_for_sip(root) is None:
-                wont_accession.append(root)
-            else:
-                # this is just batchaccessioning if no csv is supplied
-                if not oe_list:
-                    to_accession[root] = 'aaa' + str(accession_digits).zfill(4)
-                    accession_digits += 1
+    # so just reverse this - loop through the csv first.
+    # this will break the non CSV usage of batchaccession for now.
+    for thingies in oe_list:
+        for root, _, _ in sorted(os.walk(args.input)):
+            if os.path.basename(root)[:2] == 'oe' and len(os.path.basename(root)[2:]) >= 4:
+                if copyit.check_for_sip(root) is None:
+                    wont_accession.append(root)
                 else:
-                    # gets parent info
-                    if os.path.basename(root) in oe_list:
-                        to_accession[
-                            os.path.join(os.path.dirname(root),
-                                         order.main(root))
-                        ] = [
-                            'aaa' + str(accession_digits).zfill(4),
-                            ref[:2] + str(reference_digits).zfill(4)
-                        ]
-                        if root in to_accession:
-                            # If a single file is found, this prevents the file being
-                            # processed twice, with a skip in the number run
+                    # this is just batchaccessioning if no csv is supplied
+                    # this is pretty pointless at the moment seeing as this is loopline through oe_list :(
+                    if not oe_list:
+                        to_accession[root] = 'aaa' + str(accession_digits).zfill(4)
+                        accession_digits += 1
+                    else:
+                        # gets parent info
+                        if os.path.basename(root) == thingies:
+                            to_accession[
+                                os.path.join(os.path.dirname(root),
+                                             order.main(root))
+                            ] = [
+                                'aaa' + str(accession_digits).zfill(4),
+                                ref[:2] + str(reference_digits).zfill(4)
+                            ]
+                            if root in to_accession:
+                                # If a single file is found, this prevents the file being
+                                # processed twice, with a skip in the number run
+                                reference_digits += 1
+                                accession_digits += 1
+                                continue
+                            accession_digits += 1
+                            # gets reproduction info
+                            to_accession[root] = ['aaa' + str(accession_digits).zfill(4), ref[:2] + str(reference_digits), 'reproduction']
                             reference_digits += 1
                             accession_digits += 1
-                            continue
-                        accession_digits += 1
-                        # gets reproduction info
-                        to_accession[root] = ['aaa' + str(accession_digits).zfill(4), ref[:2] + str(reference_digits), 'reproduction']
-                        reference_digits += 1
-                        accession_digits += 1
     for fails in wont_accession:
         print '%s looks like it is not a fully formed SIP. Perhaps loopline_repackage.py should proccess it?' % fails
     for success in sorted(to_accession.keys()):


### PR DESCRIPTION
So based on a discussion with @aoifefitz2016 , this solution was seen as the best short/medium term solution for the following issue:

* Packages were being accessioned in the order that they were Object Entry'd, rather than the order that they were catalogued.
This meant that 
* oe8000 was ultimately catalogued as 'Rushes 9'
* oe8001 was catalogued as 'Rushes 1'

but af10000 would be assigned to whatever the first object entry number was, which in this case would have been 'Rushes 9'.
So the accessioned/filmographic lists would end up looking like:
AF10050=Rushes 9
AF10051=Rushes 5
AF10052=Rushes 37
AF10053=Rushes 1

as opposed to what we want, which is
AF10050=Rushes 1
AF10051=Rushes 2
AF10052=Rushes 3
AF10053=Rushes 4

Another issue was that 'natural sorting' was not taking place. This meant that a folder containing
[oe7890, oe10050, oe4]
would be sorted as
[oe10050, oe4, oe7890]

when what we would really want is sorting like this:

[oe4, oe7890, oe10050]

test batches should be run on this prior to merging and running in a live accessioning environment, but I think it should be fine.