### PR TITLE
Copyit rootfix

### DIFF
--- a/copyit.py
+++ b/copyit.py
@@ -711,6 +711,7 @@ def main(args_):
                 with open(manifest_temp[1], 'wb') as temp_object:
                     for i in dest_manifest_list:
                         temp_object.write(i[:33] + ' ' + dirname + '/' +  i[34:])
+                legacy_manifest = manifest
                 manifest = manifest_temp[1]
         verify_copy(
             manifest, manifest_destination, log_name_source, overwrite_destination_manifest, files_in_manifest, destination_count, source_count
@@ -719,6 +720,10 @@ def main(args_):
         if os.path.normpath(os.path.dirname(manifest)) == os.path.normpath(desktop_manifest_dir):
             os.rename(manifest, manifest_rename)
             shutil.move(manifest_rename, os.path.join(desktop_manifest_dir, 'old_manifests'))
+            if rootpos == 'y':
+                legacy_manifest_rename = legacy_manifest[:-4] + time.strftime("_%Y_%m_%dT%H_%M_%S") + '.md5'
+                os.rename(legacy_manifest, legacy_manifest_rename)
+                shutil.move(legacy_manifest_rename, os.path.join(desktop_manifest_dir, 'old_manifests'))
         # hack to also copy the sha512 manifest :(
         # Stop the temp manifest from copying
         if not os.path.basename(manifest_temp[1]) == os.path.basename(manifest):

--- a/copyit.py
+++ b/copyit.py
@@ -326,13 +326,16 @@ def check_overwrite_dir(dir2check):
     Asks user if they want to overwrite a pre-existing destination directory.
     '''
     if os.path.isdir(dir2check):
-        print('A directory already exists at your destination. Overwrite? Y/N?')
-        overwrite_destination_dir = ''
-        while overwrite_destination_dir not in ('Y', 'y', 'N', 'n'):
-            overwrite_destination_dir = raw_input()
-            if overwrite_destination_dir not in ('Y', 'y', 'N', 'n'):
-                print('Incorrect input. Please enter Y or N')
-        return overwrite_destination_dir
+        if len(os.listdir(dir2check)) > 1:
+            print('A directory already exists at your destination. Overwrite? Y/N?')
+            overwrite_destination_dir = ''
+            while overwrite_destination_dir not in ('Y', 'y', 'N', 'n'):
+                overwrite_destination_dir = raw_input()
+                if overwrite_destination_dir not in ('Y', 'y', 'N', 'n'):
+                    print('Incorrect input. Please enter Y or N')
+            return overwrite_destination_dir
+        else:
+            print('A directory exists in your destination but it is empty so we shall proceed')
 
 def check_for_sip(args):
     '''

--- a/copyit.py
+++ b/copyit.py
@@ -624,6 +624,7 @@ def main(args_):
     '''
     Launches the functions that will safely copy and paste your files.
     '''
+    manifest_temp = '--' # add two characters so that I can slice for manifest_temp[1] later.
     dircheck = None
     args, rootpos, manifest_sidecar, log_name_source, destination_final_path, manifest_root, manifest_destination, manifest, destination, dirname, desktop_manifest_dir = setup(args_)
     if os.path.isdir(args.source):
@@ -708,10 +709,12 @@ def main(args_):
             os.rename(manifest, manifest_rename)
             shutil.move(manifest_rename, os.path.join(desktop_manifest_dir, 'old_manifests'))
         # hack to also copy the sha512 manifest :(
-        sha512_manifest = manifest.replace('_manifest.md5', '_manifest-sha512.txt')
-        if os.path.isfile(sha512_manifest):
-            shutil.copy2(sha512_manifest, os.path.dirname(destination_final_path))
-            print '%s has been copied to %s' % (sha512_manifest, os.path.dirname(destination_final_path))
+        # Stop the temp manifest from copying
+        if not os.path.basename(manifest_temp[1]) == os.path.basename(manifest):
+            sha512_manifest = manifest.replace('_manifest.md5', '_manifest-sha512.txt')
+            if os.path.isfile(sha512_manifest):
+                shutil.copy2(sha512_manifest, os.path.dirname(destination_final_path))
+                print '%s has been copied to %s' % (sha512_manifest, os.path.dirname(destination_final_path))
         return log_name_source
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/copyit.py
+++ b/copyit.py
@@ -416,7 +416,10 @@ def setup(args_):
         manifest_destination = destination + '/%s_manifest.md5' % dirname
     if os.path.isfile(manifest_destination):
         print('Destination manifest already exists')
-    manifest_filename = '%s_manifest.md5' % dirname
+    if rootpos == 'y':
+        manifest_filename = '%s_manifest.md5' % os.path.basename(destination)
+    else:
+        manifest_filename = '%s_manifest.md5' % dirname
     desktop_manifest_dir = make_desktop_manifest_dir()
     # manifest = desktop manifest, looks like this can get rewritten later.
     manifest = os.path.join(

--- a/copyit.py
+++ b/copyit.py
@@ -713,7 +713,7 @@ def main(args_):
             manifest, manifest_destination, log_name_source, overwrite_destination_manifest, files_in_manifest, destination_count, source_count
         )
         manifest_rename = manifest[:-4] + time.strftime("_%Y_%m_%dT%H_%M_%S") + '.md5'
-        if os.path.dirname(manifest) == desktop_manifest_dir:
+        if os.path.normpath(os.path.dirname(manifest)) == os.path.normpath(desktop_manifest_dir):
             os.rename(manifest, manifest_rename)
             shutil.move(manifest_rename, os.path.join(desktop_manifest_dir, 'old_manifests'))
         # hack to also copy the sha512 manifest :(

--- a/copyit.py
+++ b/copyit.py
@@ -407,7 +407,10 @@ def setup(args_):
     relative_path = normpath.split(os.sep)[-1]
     # or hardcode
     destination_final_path = os.path.join(destination, dirname)
-    manifest_destination = destination + '/%s_manifest.md5' % dirname
+    if rootpos == 'y':
+        manifest_destination = os.path.dirname(destination) + '/%s_manifest.md5' % os.path.basename(destination)
+    else:
+        manifest_destination = destination + '/%s_manifest.md5' % dirname
     if os.path.isfile(manifest_destination):
         print('Destination manifest already exists')
     manifest_filename = '%s_manifest.md5' % dirname
@@ -548,7 +551,7 @@ def make_destination_manifest(
         if rootpos == 'y':
             files_in_manifest = make_manifest(
                 destination_final_path,
-                manifest_destination, destination
+                manifest_destination, os.path.dirname(destination)
             )
             generate_log(
                 log_name_source,

--- a/copyit.py
+++ b/copyit.py
@@ -710,7 +710,7 @@ def main(args_):
                 dest_manifest_list = fo.readlines()
                 with open(manifest_temp[1], 'wb') as temp_object:
                     for i in dest_manifest_list:
-                        temp_object.write(i[:33] + ' ' + dirname + '/' +  i[34:])
+                        temp_object.write(i[:33] + ' ' + os.path.basename(os.path.dirname(destination_final_path)) + '/' +  i[34:])
                 legacy_manifest = manifest
                 manifest = manifest_temp[1]
         verify_copy(

--- a/copyit.py
+++ b/copyit.py
@@ -399,9 +399,11 @@ def setup(args_):
     dirname = os.path.split(os.path.basename(source))[1]
     if dirname == '':
         rootpos = 'y'
+        '''
         dirname = raw_input(
             'What do you want your destination folder to be called?\n'
         )
+        '''
     relative_path = normpath.split(os.sep)[-1]
     # or hardcode
     destination_final_path = os.path.join(destination, dirname)

--- a/deletefiles.py
+++ b/deletefiles.py
@@ -69,6 +69,16 @@ def main(args_):
         sip_manifest = os.path.join(
             oe_path, uuid
             ) + '_manifest.md5'
+    else:
+        # this is assuming that the other workflow will be the
+        # special collections workflow that has the uuid as the parent.
+        # some real checks should exist for this whole if/else flow.
+        sip_path = args.input
+        oe_path = os.path.dirname(args.input)
+        uuid = os.path.basename(sip_path)
+        sip_manifest = os.path.join(
+            oe_path, uuid + '_manifest.md5'
+            )
     start = datetime.datetime.now()
     print args
     if args.user:

--- a/deletefiles.py
+++ b/deletefiles.py
@@ -23,7 +23,7 @@ def parse_args(args_):
         help='full path of files to be deleted', required=True
     )
     parser.add_argument(
-        'input',
+        '-uuid_path',
         help='full path of \'sipcreator\' Object Entry package'
     )
     parser.add_argument(
@@ -61,7 +61,7 @@ def main(args_):
     Launch all the functions for creating an IFI SIP.
     '''
     args = parse_args(args_)
-    source = args.input
+    source = args.uuid_path
     sip_path = ififuncs.check_for_sip([source])
     if sip_path is not None:
         oe_path = os.path.dirname(sip_path)
@@ -73,8 +73,8 @@ def main(args_):
         # this is assuming that the other workflow will be the
         # special collections workflow that has the uuid as the parent.
         # some real checks should exist for this whole if/else flow.
-        sip_path = args.input
-        oe_path = os.path.dirname(args.input)
+        sip_path = args.uuid_path
+        oe_path = os.path.dirname(args.uuid_path)
         uuid = os.path.basename(sip_path)
         sip_manifest = os.path.join(
             oe_path, uuid + '_manifest.md5'

--- a/package_update.py
+++ b/package_update.py
@@ -117,20 +117,23 @@ def main(args_):
         os.makedirs(args.new_folder)
     for filenames in args.i:
         if args.copy:
-            for filename in filenames:
-                copyit.main([filename, args.new_folder])
-                ififuncs.generate_log(
-                    new_log_textfile,
-                    'EVENT = eventType=file movement,'
-                    ' eventOutcomeDetailNote=%s has been moved into %s'
-                    ' agentName=copyit.py'
-                    % (filename, args.new_folder)
-                )
-                # this is hardcoded - pick this apart so that any folder can be added to.
-                sipcreator.consolidate_manifests(sip_path, 'metadata/supplemental', new_log_textfile)
-                log_manifest = os.path.join(os.path.dirname(new_log_textfile), os.path.basename(filename) + '_manifest.md5')
-                ififuncs.manifest_update(sip_manifest, log_manifest)
-                ififuncs.sort_manifest(sip_manifest)
+            copyit.main([filenames, args.new_folder])
+            ififuncs.generate_log(
+                new_log_textfile,
+                'EVENT = eventType=file movement,'
+                ' eventOutcomeDetailNote=%s has been moved into %s'
+                ' agentName=copyit.py'
+                % (filenames, args.new_folder)
+            )
+            # this is hardcoded - pick this apart so that any folder can be added to.
+            # this must be fixed in normalise.py as well.
+            relative_new_path = args.new_folder.replace(sip_path, '')
+            if relative_new_path[0] == '/':
+                relative_new_path = relative_new_path[1:]
+            sipcreator.consolidate_manifests(sip_path, relative_new_path, new_log_textfile)
+            log_manifest = os.path.join(os.path.dirname(new_log_textfile), os.path.basename(filenames) + '_manifest.md5')
+            ififuncs.manifest_update(sip_manifest, log_manifest)
+            ififuncs.sort_manifest(sip_manifest)
         else:
             # add test to see if it actually deleted - what if read only?
             shutil.move(filenames, args.new_folder)

--- a/package_update.py
+++ b/package_update.py
@@ -116,6 +116,11 @@ def main(args_):
     if not os.path.isdir(args.new_folder):
         os.makedirs(args.new_folder)
     for filenames in args.i:
+        if isinstance(filenames, (list,)):
+            # due to the nature of argparse nargs, you can end up with
+            # a list within a list when passing the -supplement values
+            # between scripts.
+            filenames = filenames[0]
         if args.copy:
             copyit.main([filenames, args.new_folder])
             ififuncs.generate_log(

--- a/package_update.py
+++ b/package_update.py
@@ -85,11 +85,11 @@ def main(args_):
         # special collections workflow that has the uuid as the parent.
         # some real checks should exist for this whole if/else flow.
         sip_path = args.input
-        oe_path = args.input
-        uuid = os.path.basename(oe_path)
+        oe_path = os.path.dirname(args.input)
+        uuid = os.path.basename(sip_path)
         sip_manifest = os.path.join(
-            oe_path, uuid
-            ) + '_manifest.md5'
+            oe_path, uuid + '_manifest.md5'
+            )
     start = datetime.datetime.now()
     print args
     if args.user:
@@ -133,23 +133,25 @@ def main(args_):
                 ififuncs.sort_manifest(sip_manifest)
         else:
             # add test to see if it actually deleted - what if read only?
-            shutil.move(filename, args.new_folder)
+            shutil.move(filenames, args.new_folder)
             ififuncs.generate_log(
                 new_log_textfile,
                 'EVENT = eventType=file movement,'
                 ' eventOutcomeDetailNote=%s has been moved into %s'
                 ' agentName=shutil.move()'
-                % (filename, args.new_folder)
+                % (filenames, args.new_folder)
             )
-        print '%s has been moved into %s' % (filename, args.new_folder)
-        relative_filename = filename.replace(args.input + '/', '')
-        relative_new_folder = args.new_folder.replace(args.input + '/', '')
-        update_manifest(
-            sip_manifest,
-            relative_filename,
-            os.path.join(relative_new_folder, os.path.basename(relative_filename)),
-            new_log_textfile
-        )
+            print '%s has been moved into %s' % (filenames, args.new_folder)
+            relative_filename = filenames.replace(os.path.dirname(args.input) + '/', '').replace('\\', '/')
+            relative_filename = filenames.replace(os.path.dirname(args.input) + '\\', '').replace('\\', '/')
+            relative_new_folder = args.new_folder.replace(os.path.dirname(args.input) + '/', '').replace('\\', '/')
+            relative_new_folder = args.new_folder.replace(os.path.dirname(args.input) + '\\', '').replace('\\', '/')
+            update_manifest(
+                sip_manifest,
+                relative_filename,
+                os.path.join(relative_new_folder, os.path.basename(relative_filename)).replace('\\', '/'),
+                new_log_textfile
+            )
     ififuncs.generate_log(
         new_log_textfile,
         'EVENT = package_update.py finished'

--- a/package_update.py
+++ b/package_update.py
@@ -80,6 +80,16 @@ def main(args_):
         sip_manifest = os.path.join(
             oe_path, uuid
             ) + '_manifest.md5'
+    else:
+        # this is assuming that the other workflow will be the 
+        # special collections workflow that has the uuid as the parent.
+        # some real checks should exist for this whole if/else flow.
+        sip_path = args.input
+        oe_path = args.input
+        uuid = os.path.basename(oe_path)
+        sip_manifest = os.path.join(
+            oe_path, uuid
+            ) + '_manifest.md5'
     start = datetime.datetime.now()
     print args
     if args.user:

--- a/package_update.py
+++ b/package_update.py
@@ -115,12 +115,9 @@ def main(args_):
     )
     if not os.path.isdir(args.new_folder):
         os.makedirs(args.new_folder)
+    if isinstance(args.i[0], (list,)):
+        args.i = args.i[0]
     for filenames in args.i:
-        if isinstance(filenames, (list,)):
-            # due to the nature of argparse nargs, you can end up with
-            # a list within a list when passing the -supplement values
-            # between scripts.
-            filenames = filenames[0]
         if args.copy:
             copyit.main([filenames, args.new_folder])
             ififuncs.generate_log(

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -304,20 +304,21 @@ def normalise_objects_manifest(sip_path):
     into the objects directory.
     '''
     objects_manifest = os.path.join(sip_path, 'objects_manifest.md5')
-    updated_manifest_lines = []
-    with open(objects_manifest, 'r') as fo:
-        manifest_lines = fo.readlines()
-        for i in manifest_lines:
-            # This is what appends the new path to existing paths.
-            replacement = i.replace('  objects/', '  ')
-            updated_manifest_lines.append(replacement)
-    with open(objects_manifest, 'w') as fo:
-        for x in updated_manifest_lines:
-            fo.write(x)
-    # Cut and paste old manifests into the log directory
-    shutil.move(
-        objects_manifest, os.path.join(sip_path, 'objects')
-    )
+    if os.path.isfile(objects_manifest):
+        updated_manifest_lines = []
+        with open(objects_manifest, 'r') as fo:
+            manifest_lines = fo.readlines()
+            for i in manifest_lines:
+                # This is what appends the new path to existing paths.
+                replacement = i.replace('  objects/', '  ')
+                updated_manifest_lines.append(replacement)
+        with open(objects_manifest, 'w') as fo:
+            for x in updated_manifest_lines:
+                fo.write(x)
+        # Cut and paste old manifests into the log directory
+        shutil.move(
+            objects_manifest, os.path.join(sip_path, 'objects')
+        )
 
 def main(args_):
     '''

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -297,6 +297,27 @@ def create_content_title_text(sip_path):
         os.rename(os.path.basename(dcp_dirname), content_title_text)
     return content_title_text
 
+def normalise_objects_manifest(sip_path):
+    '''
+    For a root copy workflow, the objects manifest is in the
+    uuid directory, not the objects directory. This will move it
+    into the objects directory.
+    '''
+    objects_manifest = os.path.join(sip_path, 'objects_manifest.md5')
+    updated_manifest_lines = []
+    with open(objects_manifest, 'r') as fo:
+        manifest_lines = fo.readlines()
+        for i in manifest_lines:
+            # This is what appends the new path to existing paths.
+            replacement = i.replace('  objects/', '  ')
+            updated_manifest_lines.append(replacement)
+    with open(objects_manifest, 'w') as fo:
+        for x in updated_manifest_lines:
+            fo.write(x)
+    # Cut and paste old manifests into the log directory
+    shutil.move(
+        objects_manifest, os.path.join(sip_path, 'objects')
+    )
 
 def main(args_):
     '''
@@ -385,6 +406,8 @@ def main(args_):
     ififuncs.hashlib_manifest(
         metadata_dir, metadata_dir + '/metadata_manifest.md5', metadata_dir
     )
+    if args.sc:
+        normalise_objects_manifest(sip_path)
     new_manifest_textfile = consolidate_manifests(sip_path, 'objects', new_log_textfile)
     consolidate_manifests(sip_path, 'metadata', new_log_textfile)
     ififuncs.hashlib_append(

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -23,7 +23,10 @@ def make_folder_path(path, args, object_entry):
         representation_uuid = ififuncs.create_uuid()
     else:
         representation_uuid = args.u
-    oe_path = os.path.join(path, object_entry)
+    if args.sc:
+        oe_path = args.o
+    else:
+        oe_path = os.path.join(path, object_entry)
     path = os.path.join(oe_path, representation_uuid)
     print path
     ififuncs.make_folder_structure(path)
@@ -170,6 +173,10 @@ def parse_args(args_):
         help='invokes the -move argument in copyit.py - moves instead of copy.'
     )
     parser.add_argument(
+        '-sc', action='store_true',
+        help='special collections workflow'
+    )
+    parser.add_argument(
         '-oe',
         help='Enter the Object Entry number for the representation.SIP will be placed in a folder with this name.'
     )
@@ -303,20 +310,23 @@ def main(args_):
         user = args.user
     else:
         user = ififuncs.get_user()
-    if args.oe:
-        if args.oe[:2] != 'oe':
-            print 'First two characters must be \'oe\' and last four characters must be four digits'
-            object_entry = ififuncs.get_object_entry()
-        elif len(args.oe[2:]) not in range(4, 6):
-            print 'First two characters must be \'oe\' and last four characters must be four digits'
-            object_entry = ififuncs.get_object_entry()
-        elif not args.oe[2:].isdigit():
-            object_entry = ififuncs.get_object_entry()
-            print 'First two characters must be \'oe\' and last four characters must be four digits'
+    if not args.sc:
+        if args.oe:
+            if args.oe[:2] != 'oe':
+                print 'First two characters must be \'oe\' and last four characters must be four digits'
+                object_entry = ififuncs.get_object_entry()
+            elif len(args.oe[2:]) not in range(4, 6):
+                print 'First two characters must be \'oe\' and last four characters must be four digits'
+                object_entry = ififuncs.get_object_entry()
+            elif not args.oe[2:].isdigit():
+                object_entry = ififuncs.get_object_entry()
+                print 'First two characters must be \'oe\' and last four characters must be four digits'
+            else:
+                object_entry = args.oe
         else:
-            object_entry = args.oe
+            object_entry = ififuncs.get_object_entry()
     else:
-        object_entry = ififuncs.get_object_entry()
+        object_entry = 'not_applicable'
     sip_path = make_folder_path(os.path.join(args.o), args, object_entry)
     if args.u:
         if ififuncs.validate_uuid4(args.u) is None:
@@ -360,12 +370,13 @@ def main(args_):
     )
     if args.u is False:
         sys.exit()
-    ififuncs.generate_log(
-        new_log_textfile,
-        'EVENT = eventType=Identifier assignement,'
-        ' eventIdentifierType=object entry, value=%s'
-        % object_entry
-    )
+    if not args.sc:
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = eventType=Identifier assignement,'
+            ' eventIdentifierType=object entry, value=%s'
+            % object_entry
+        )
     metadata_dir = os.path.join(sip_path, 'metadata')
     supplemental_dir = os.path.join(metadata_dir, 'supplemental')
     logs_dir = os.path.join(sip_path, 'logs')


### PR DESCRIPTION
This is the beginning of the long-overdue fixes for https://github.com/kieranjol/IFIscripts/issues/284 - namely copying from the root of an external drive on Windows which is often a pain in the neck for pretty much any workflow that involves hard drives being delivered.

From what i can see so far, the following should be fixed:
* ~~There is no need for the interview question `what do you want your destination folder to be called?`~~
* ~~The temp manifest is being copied to the destination dir.~~
* ~~The destination manifest is called `_manifest.md5` and instead it should...:~~
* ~~exist one directory UP, and take on the name of the directory it is referencing.~~
* to fulfill the previous step, a folder will have to exist and be empty (I think) and i think this will rule out copying directly to the root of another drive. This is hopefully a limitation that can be overcome though.
* ~~In `moveit_manifests`, the destination manifest hangs around and causes issues with further copyit jobs.~~
* ~~You get asked twice about overwriting a destination folder~~
~~* Make sure it works with sipcreating a drive~~
* Perhaps a refactoring is needed at the end as all this `rootpos` business is inefficient and weird.
~~* The actual success check is giving a false negative~~
~~* In order to be able to transfer a file into a folder that already contains files and a manifest, perhaps the manifest should be updated, but only with a command line argument. the script should exit otherwise, but with a message pointing the user in the direction of the arg.EDIT - turns out this is a non-issue <3~~