### PR TITLE
seq2ffv1 - implements rawcooked encoder

### DIFF
--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1503,6 +1503,20 @@ def get_mediainfo_version():
         mediainfo_version = grepexc.output.rstrip().splitlines()[1]
     return mediainfo_version
 
+def get_rawcooked_version():
+    '''
+    Returns the version of rawcooked.
+    If this is not possible, the string 'RAWcooked' is returned.
+    '''
+    rawcooked_version = 'RAWcooked'
+    try:
+        rawcooked_version = subprocess.check_output([
+            'rawcooked', '--version'
+        ]).rstrip()
+    except subprocess.CalledProcessError as grepexc:
+        rawcooked_version = grepexc.output.rstrip().splitlines()[1]
+    return rawcooked_version
+
 def get_ffprobe_dict(source):
     '''
     Returns a dictionary via the ffprobe JSON output

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -102,7 +102,36 @@ def make_mediaconch(full_path, mediaconch_xmlfile):
     with open(mediaconch_xmlfile, 'wb') as xmlfile:
         xmlfile.write(mediaconch_output)
 
+def extract_provenance(filename, output_folder, output_uuid):
+    '''
+    This will extract mediainfo and mediatrace XML
+    '''
+    inputxml = "%s/%s_source_mediainfo.xml" % (output_folder, output_uuid)
+    inputtracexml = "%s/%s_source_mediatrace.xml" % (output_folder, output_uuid)
+    print(' - Generating mediainfo xml of input file and saving it in %s' % inputxml)
+    make_mediainfo(inputxml, 'mediaxmlinput', filename)
+    print(' - Generating mediatrace xml of input file and saving it in %s' % inputtracexml)
+    make_mediatrace(inputtracexml, 'mediatracexmlinput', filename)
+    return inputxml, inputtracexml
 
+def generate_mediainfo_xmls(filename, output_folder, output_uuid, log_name_source):
+    '''
+    This will add the mediainfo xmls to the package
+    '''
+    inputxml, inputtracexml = extract_provenance(filename, output_folder, output_uuid)
+    mediainfo_version = get_mediainfo_version()
+    generate_log(
+        log_name_source,
+        'EVENT = Metadata extraction - eventDetail=Technical metadata extraction via mediainfo, eventOutcome=%s, agentName=%s' % (inputxml, mediainfo_version)
+    )
+    generate_log(
+        log_name_source,
+        'EVENT = Metadata extraction - eventDetail=Mediatrace technical metadata extraction via mediainfo, eventOutcome=%s, agentName=%s' % (inputtracexml, mediainfo_version)
+    )
+    generate_log(
+        log_name_source,
+        'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=MD5s of AV streams of output file generated for validation')
+    return inputxml, inputtracexml
 def make_qctools(input):
     '''
     Runs an ffprobe process that stores QCTools XML info as a variable.

--- a/normalise.py
+++ b/normalise.py
@@ -48,17 +48,7 @@ def parse_args(args_):
     )
     parsed_args = parser.parse_args(args_)
     return parsed_args
-def extract_provenance(filename, output_folder, output_uuid):
-    '''
-    This will extract mediainfo and mediatrace XML
-    '''
-    inputxml = "%s/%s_source_mediainfo.xml" % (output_folder, output_uuid)
-    inputtracexml = "%s/%s_source_mediatrace.xml" % (output_folder, output_uuid)
-    print(' - Generating mediainfo xml of input file and saving it in %s' % inputxml)
-    ififuncs.make_mediainfo(inputxml, 'mediaxmlinput', filename)
-    print(' - Generating mediatrace xml of input file and saving it in %s' % inputtracexml)
-    ififuncs.make_mediatrace(inputtracexml, 'mediatracexmlinput', filename)
-    return inputxml, inputtracexml
+
 
 def normalise_process(filename, output_folder):
     '''
@@ -193,19 +183,7 @@ def main(args_):
         ififuncs.generate_log(
             log_name_source,
             'EVENT = Normalization, status=finished, eventType=Normalization, agentName=ffmpeg, eventDetail=Source object normalised into=%s' % output)
-        inputxml, inputtracexml = extract_provenance(filename, output_folder, output_uuid)
-        mediainfo_version = ififuncs.get_mediainfo_version()
-        ififuncs.generate_log(
-            log_name_source,
-            'EVENT = Metadata extraction - eventDetail=Technical metadata extraction via mediainfo, eventOutcome=%s, agentName=%s' % (inputxml, mediainfo_version)
-        )
-        ififuncs.generate_log(
-            log_name_source,
-            'EVENT = Metadata extraction - eventDetail=Mediatrace technical metadata extraction via mediainfo, eventOutcome=%s, agentName=%s' % (inputtracexml, mediainfo_version)
-        )
-        ififuncs.generate_log(
-            log_name_source,
-            'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=MD5s of AV streams of output file generated for validation')
+        inputxml, inputtracexml = ififuncs.generate_mediainfo_xmls(filename, output_folder, output_uuid, log_name_source)
         fmd5_logfile, fmd5ffv1, verdict = verify_losslessness(output_folder, output, output_uuid, fmd5)
         ififuncs.generate_log(
             log_name_source,

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -148,7 +148,13 @@ def make_ffv1(
             '-f', 'framemd5', source_textfile
         ]
         print source_abspath
-        subprocess.call(['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path])
+        rawcooked_logfile = os.path.join(
+        temp_dir, '%s_rawcooked.log' % uuid
+        )
+        files_to_move.append(rawcooked_logfile)
+        rawcooked_logfile = "\'" + rawcooked_logfile + "\'"
+        rawcooked_env_dict = ififuncs.set_environment(rawcooked_logfile)
+        subprocess.call(['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path], env=rawcooked_env_dict)
     else:
         ffv12dpx = [
             'ffmpeg', '-report',

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -66,7 +66,6 @@ def run_loop(args):
             start_number,
             source_abspath,
             output_dirname,
-            root_filename,
             args,
             log_name_source
         )
@@ -103,7 +102,6 @@ def make_ffv1(
         start_number,
         source_abspath,
         output_dirname,
-        root_filename,
         args,
         log_name_source
     ):
@@ -163,9 +161,9 @@ def make_ffv1(
         ffv12dpx = (['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path])
     else:
         logfile = os.path.join(
-        temp_dir,
-        '%s_ffv1_transcode.log' % uuid
-        )
+            temp_dir,
+            '%s_ffv1_transcode.log' % uuid
+            )
         files_to_move.append(logfile)
         logfile = "\'" + logfile + "\'"
         env_dict = ififuncs.set_environment(logfile)
@@ -188,14 +186,16 @@ def make_ffv1(
         normalisation_tool = 'FFmpeg'
     print ffv12dpx
     ififuncs.generate_log(
-            log_name_source,
-            'EVENT = normalisation, status=started, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
-        % normalisation_tool)
+        log_name_source,
+        'EVENT = normalisation, status=started, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
+        % normalisation_tool
+    )
     subprocess.call(ffv12dpx, env=env_dict)
     ififuncs.generate_log(
-            log_name_source,
-            'EVENT = normalisation, status=finshed, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
-        % normalisation_tool)
+        log_name_source,
+        'EVENT = normalisation, status=finshed, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
+        % normalisation_tool
+    )
     ffv1_md5 = os.path.join(
         temp_dir,
         uuid + '_ffv1.framemd5'

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -41,7 +41,7 @@ def short_test(images, args):
     temp_dir = os.path.join(tempfile.gettempdir(), temp_uuid)
     os.makedirs(temp_dir)
     for image in images[:24]:
-        full_path = os.path.join(args.source_directory, image)
+        full_path = os.path.join(args.i, image)
         shutil.copy(full_path, temp_dir)
     mkv_uuid = ififuncs.create_uuid()
     mkv_file = os.path.join(tempfile.gettempdir(), mkv_uuid + '.mkv')
@@ -65,7 +65,7 @@ def run_loop(args):
     else:
         user = ififuncs.get_user()
     log_name_source = os.path.join(
-        args.destination, '%s_seq2ffv1_log.log' % time.strftime("_%Y_%m_%dT%H_%M_%S")
+        args.o, '%s_seq2ffv1_log.log' % time.strftime("_%Y_%m_%dT%H_%M_%S")
     )
     ififuncs.generate_log(log_name_source, 'seq2ffv1.py started.')
     ififuncs.generate_log(
@@ -80,8 +80,8 @@ def run_loop(args):
         'EVENT = agentName=%s' % user
     )
     verdicts = []
-    for source_directory, _, _ in os.walk(args.source_directory):
-        output_dirname = args.destination
+    for source_directory, _, _ in os.walk(args.i):
+        output_dirname = args.o
         images = ififuncs.get_image_sequence_files(source_directory)
         if images == 'none':
             continue
@@ -300,11 +300,11 @@ def setup():
                                      ' in a Matroska Container.'
                                      ' Written by Kieran O\'Leary.')
     parser.add_argument(
-        'source_directory',
+        '-i',
         help='Input directory'
     )
     parser.add_argument(
-        'destination',
+        '-o',
         help='Destination directory'
     )
     parser.add_argument(

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -22,7 +22,6 @@ that just tests the md5s of the first 24 frames.
 import subprocess
 import os
 import argparse
-import itertools
 import tempfile
 import shutil
 import time
@@ -73,7 +72,7 @@ def run_loop(args):
             judgement, sipcreator_log, sipcreator_manifest = judgement
         verdicts.append([root_filename, judgement])
         for verdict in verdicts:
-            print "%-*s   : %s" % (50, verdict[0], verdict[1])
+            print("%-*s   : %s" % (50, verdict[0], verdict[1]))
     ififuncs.generate_log(log_name_source, 'seq2ffv1.py finished.')
     if not args.no_sip:
         ififuncs.merge_logs(log_name_source, sipcreator_log, sipcreator_manifest)
@@ -87,7 +86,7 @@ def verify_losslessness(source_textfile, ffv1_md5):
     checksum_mismatches = []
     with open(source_textfile) as source_md5_object:
         with open(ffv1_md5) as ffv1_md5_object:
-            for (line1), (line2) in itertools.izip(
+            for (line1), (line2) in zip(
                     ififuncs.read_lines(
                         source_md5_object
                     ), ififuncs.read_lines(ffv1_md5_object)
@@ -141,7 +140,7 @@ def make_ffv1(
             '-pix_fmt', pix_fmt,
             '-f', 'framemd5', source_textfile
         ]
-        print source_abspath
+        print(source_abspath)
         rawcooked_logfile = os.path.join(
             temp_dir, '%s_rawcooked.log' % uuid
         )
@@ -184,7 +183,7 @@ def make_ffv1(
             '-f', 'framemd5', source_textfile
         ]
         normalisation_tool = 'FFmpeg'
-    print ffv12dpx
+    print(ffv12dpx)
     ififuncs.generate_log(
         log_name_source,
         'EVENT = normalisation, status=started, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -157,7 +157,10 @@ def make_ffv1(
             log_name_source,
             'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of source'
         )
-        ffv12dpx = (['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path])
+        rawcooked_cmd = ['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path]
+        if args.audio:
+            rawcooked_cmd.extend([args.audio, '-c:a', 'copy'])
+        ffv12dpx = (rawcooked_cmd)
     else:
         logfile = os.path.join(
             temp_dir,
@@ -282,6 +285,9 @@ def setup():
     parser.add_argument(
         '-user',
         help='Declare who you are. If this is not set, you will be prompted.')
+    parser.add_argument(
+        '-audio',
+        help='Full path to audio file.')
     parser.add_argument(
         '-rawcooked',
         help='Use RAWcooked for the normalisation to FFV1/Matroska.', action='store_true'

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -97,13 +97,13 @@ def run_loop(args):
             args,
             log_name_source
         )
-        if not args.no_sip:
+        if args.sip:
             judgement, sipcreator_log, sipcreator_manifest = judgement
         verdicts.append([root_filename, judgement])
         for verdict in verdicts:
             print("%-*s   : %s" % (50, verdict[0], verdict[1]))
     ififuncs.generate_log(log_name_source, 'seq2ffv1.py finished.')
-    if not args.no_sip:
+    if args.sip:
         ififuncs.merge_logs(log_name_source, sipcreator_log, sipcreator_manifest)
 
 
@@ -138,7 +138,7 @@ def make_ffv1(
     as well as framemd5 losslessness verification.
     '''
     uuid = ififuncs.create_uuid()
-    if not args.no_sip:
+    if args.sip:
         object_entry = ififuncs.get_object_entry()
     files_to_move = []
     pix_fmt = ififuncs.img_seq_pixfmt(
@@ -255,7 +255,7 @@ def make_ffv1(
         log_name_source,
         'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image, eventOutcome=%s' % judgement
     )
-    if args.no_sip:
+    if not args.sip:
         return judgement
     else:
         sip_dir = os.path.join(
@@ -308,8 +308,8 @@ def setup():
         help='Destination directory'
     )
     parser.add_argument(
-        '--no-sip',
-        help='Do not run sipcreator.py on the resulting file.', action='store_true'
+        '-sip',
+        help='Run sipcreator.py on the resulting file.', action='store_true'
     )
     parser.add_argument(
         '-user',

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -261,7 +261,9 @@ def make_ffv1(
         sip_dir = os.path.join(
             os.path.dirname(ffv1_path), os.path.join(object_entry, uuid)
         )
-        sipcreator_log, sipcreator_manifest = sipcreator.main([
+        inputxml, inputtracexml = ififuncs.generate_mediainfo_xmls(os.path.dirname(source_abspath), args.o, uuid, log_name_source)
+        supplement_cmd = ['-supplement', inputxml, inputtracexml]
+        sipcreator_cmd = [
             '-i',
             ffv1_path,
             '-u',
@@ -272,9 +274,13 @@ def make_ffv1(
             'Kieran',
             '-oe',
             object_entry,
-            '-o', os.path.dirname(ffv1_path)])
+            '-o', os.path.dirname(ffv1_path)
+        ]
+        sipcreator_cmd.extend(supplement_cmd)
+        sipcreator_log, sipcreator_manifest = sipcreator.main(sipcreator_cmd)
         logs_dir = os.path.join(sip_dir, 'logs')
         metadata_dir = os.path.join(sip_dir, 'metadata')
+
         for files in files_to_move:
             if files.endswith('.log'):
                 shutil.move(files, logs_dir)


### PR DESCRIPTION
Seeing as RAWcooked is very far along and useable, it's a good time to add a `-rawcooked` option to `seq2ffv1`.

Currently, this option will replace the encoding step with a rawcooked process, everything else is the same.

Things to add are:
* Some kind of whole file md5 check
~~* a basic md5 check for the first 24 frames, just as a test to let a user know that the process will be truly lossless.~~
~~* logging to reflect the rawcooked process~~ - fixed
~~* possibly include some rawcooked logs if possible via https://github.com/MediaArea/RAWcooked/issues/144~~ fixed
* how to handle more complex packages such as
    * dpx + audio
    * multi reel dpx + audio
    * multi pass dpx with overlapping images due to multiple stop/starts of the scanner for recalibration
* detect when rawcooked will not handle a stream
~~* it's worth mirroring `normalise.py` as much as possible - including reversing the IFI-specific behaviour. Currently, `seq2ffv1.py` will create an IFI-sip via sipcreator by default, but the default should be the basic non-IFI version, with the `-sip` option launching sipcreator instead.~~
~~* mirror the provenance section of `normalise.py so that metadata is extracted from the source DPX~~
 