### PR TITLE
makepbcore- initial refactor of mediainfo to PBCore/IFI_technical CSV & MP3/AIFF/WAV support - fixes #266

### DIFF
--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1614,14 +1614,12 @@ def get_metadata(xpath_path, root, pbcore_namespace):
         xpath_path,
         namespaces={'ns':pbcore_namespace}
     )
-    print value
     if value == []:
         value = 'n/a'
     elif len(value) > 1:
         mixed_values = ''
         value_list = []
         for i in value:
-            print i.getparent()
             # Checks if multiple audio tracks have different values.
             '''
             if i.getparent().getparent().find(

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1340,7 +1340,7 @@ def recursive_file_list(video_files):
     recursive_list = []
     for root, _, filenames in os.walk(video_files):
         for filename in filenames:
-            if filename.endswith(('.MP4', '.mp4', '.mov', '.mkv', '.mxf', '.MXF')):
+            if filename.endswith(('.MP4', '.mp4', '.mov', '.mkv', '.mxf', '.MXF', '.WAV', '.wav', '.aiff', '.AIFF', 'mp3', 'MP3')):
                 recursive_list.append(os.path.join(root, filename))
     return recursive_list
 
@@ -1426,6 +1426,9 @@ def get_digital_object_descriptor(source_folder):
     mov_count = 0
     mkv_count = 0
     mp4_count = 0
+    wav_count = 0
+    aiff_count = 0
+    mp3_count = 0
     BPAV = False
     dig_object_descriptor = ''
     for root, _, filenames in os.walk(source_folder):
@@ -1438,10 +1441,22 @@ def get_digital_object_descriptor(source_folder):
                 mov_count += 1
             elif filename.lower().endswith('mp4'):
                 mp4_count += 1
+            elif filename.lower().endswith('wav'):
+                wav_count += 1
+            elif filename.lower().endswith('aiff'):
+                aiff_count += 1
+            elif filename.lower().endswith('mp3'):
+                mp3_count += 1
     if mkv_count == 1:
         dig_object_descriptor = 'Matroska'
     elif mov_count == 1:
         dig_object_descriptor = 'QuickTime'
+    elif wav_count == 1:
+        dig_object_descriptor = 'Wave'
+    elif aiff_count == 1:
+        dig_object_descriptor = 'AIFF'
+    elif mp3_count == 1:
+        dig_object_descriptor = 'MP3'
     elif mov_count > 1:
         dig_object_descriptor = 'Multiple QuickTimes'
     elif mp4_count >= 1:

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -47,7 +47,7 @@ def diff_textfiles(source_textfile, other_textfile):
 
 def make_mediainfo(xmlfilename, xmlvariable, inputfilename):
     '''
-    Writes a verbose mediainfo XML output.
+    Writes a verbose mediainfo XML output using the OLDXML schema.
     '''
     mediainfo_cmd = [
         'mediainfo',
@@ -1590,3 +1590,42 @@ def get_colour_metadata(ffprobe_dict):
         else:
             continue
     return ffmpeg_colour_list
+
+def get_metadata(xpath_path, root, pbcore_namespace):
+    '''
+    Extracts values from PBCore2 XML MediaInfo outputs.
+    '''
+    value = root.xpath(
+        xpath_path,
+        namespaces={'ns':pbcore_namespace}
+    )
+    print value
+    if value == []:
+        value = 'n/a'
+    elif len(value) > 1:
+        mixed_values = ''
+        value_list = []
+        for i in value:
+            print i.getparent()
+            # Checks if multiple audio tracks have different values.
+            '''
+            if i.getparent().getparent().find(
+                'ns:track',
+                namespaces={'ns':pbcore_namespace}
+            ).attrib['type'] == 'Audio':
+            '''
+            value_list.append(i.text)
+        # Checks if values in the list are the same(1) or different (2)
+        if len(set(value_list)) is 1:
+            value = value[0].text
+        else:
+            # Return the mixed values with pipe delimiter.
+            for x in value_list:
+                mixed_values += x + '|'
+            if mixed_values[-1] == '|':
+                mixed_values = mixed_values[:-1]
+            value = mixed_values
+
+    else:
+        value = value[0].text
+    return value

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -30,7 +30,6 @@ def process_mixed_values(value_list):
     mixed_values = ''
     # Check if just a single value exists. If so, just return that one value.
     if len(set(value_list)) is 1:
-        print value_list
         value = value_list[0]
     else:
         # Return the mixed values with pipe delimiter.

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -411,40 +411,41 @@ def main(args_):
                         "//ns:Format_Profile",
                         new_root, mediainfo_namespace
                     )
-                elif track.text == 'Audio':
+                elif track.attrib['type'] == 'Audio':
                     silence = False
-                    essenceTrackEncod_au = get_metadata(
-                        "ns:essenceTrackEncoding",
-                        track.getparent(), pbcore_namespace
+                    essenceTrackEncod_au = ififuncs.get_metadata(
+                        "ns:Format",
+                        track, mediainfo_namespace
                     )
                     audio_codec_list.append(essenceTrackEncod_au)
-                    acodec_attributes = get_attributes(track.getparent(), pbcore_namespace)
-                    try:
-                        audio_codecid = acodec_attributes['ref']
-                    except KeyError:
-                        audio_codecid = 'n/a'
+                    #acodec_attributes = get_attributes(track.getparent(), pbcore_namespace)
+
+                    audio_codecid = ififuncs.get_metadata(
+                        "ns:CodecID",
+                        track, mediainfo_namespace
+                    )
                     essenceTrackSampling = ififuncs.get_mediainfo(
                         'samplerate',
                         '--inform=Audio;%SamplingRate_String%', source
                     )
                     sample_rate_list.append(essenceTrackSampling)
-                    essenceBitDepth_au = get_metadata(
-                        "ns:essenceTrackBitDepth",
-                        track.getparent(), pbcore_namespace
+                    essenceBitDepth_au = ififuncs.get_metadata(
+                        "ns:BitDepth",
+                        track, mediainfo_namespace
                     )
                     audio_codecid_list.append(audio_codecid)
                     au_bitdepth_list.append(essenceBitDepth_au)
-                    channels = get_metadata(
-                        "//ns:essenceTrackAnnotation[@annotationType='Channel(s)']",
-                        track.getparent(), pbcore_namespace
+                    channels = ififuncs.get_metadata(
+                        "//ns:Channels",
+                        track, mediainfo_namespace
                     )
                     channels_list.append(channels)
-        ScanType = get_metadata(
+        ScanType = ififuncs.get_metadata(
             "//ns:ScanType",
             new_root, mediainfo_namespace
         )
         scan_types.append(ScanType)
-        matrix_coefficients = get_metadata(
+        matrix_coefficients = ififuncs.get_metadata(
             "//ns:matrix_coefficients",
             new_root, mediainfo_namespace
         )

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -394,7 +394,7 @@ def main(args_):
         if len(new_track_type) > 0:
             for track in new_track_type:
                 if track.attrib['type'] == 'Video':
-                    audio_only = True
+                    audio_only = False
                     essenceTrackEncodvid = ififuncs.get_metadata(
                         "ns:Format",
                         track, mediainfo_namespace

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -400,16 +400,16 @@ def main(args_):
                     #vcodec_attributes = get_attributes(track.getparent(), pbcore_namespace)
                     #vcodec_attributes = 'TODO'
                     video_codecid = ififuncs.get_metadata(
-                        "//ns:CodecID",
-                        new_root, mediainfo_namespace
+                        "ns:CodecID",
+                        track, mediainfo_namespace
                     )
                     video_codec_version =  ififuncs.get_metadata(
-                        "//ns:Format_Version",
-                        new_root, mediainfo_namespace
+                        "ns:Format_Version",
+                        track, mediainfo_namespace
                     )
                     video_codec_profile = ififuncs.get_metadata(
-                        "//ns:Format_Profile",
-                        new_root, mediainfo_namespace
+                        "ns:Format_Profile",
+                        track, mediainfo_namespace
                     )
                 elif track.attrib['type'] == 'Audio':
                     silence = False
@@ -538,7 +538,7 @@ def main(args_):
         )
         # this needs to be clarified as it exists in general and codec
         format_version = ififuncs.get_metadata(
-            "//ns:Format_Version",
+            "ns:Format_Version",
             general_root, mediainfo_namespace
         )
         app_company_name = ififuncs.get_metadata(


### PR DESCRIPTION
This is an attempt to re-factor the technical metadata extraction so that it does not use the PBCore2 output. This mediainfo output will continue to change, so it's not a good source for scripting/transformation.
This patch uses the modern XML mediainfo schema instead, but there are still a few fields that use PBCore2XML.
This also has the perk of allowing us to update mediainfo on our computers as we are currently using an older version,prior to the PBCore2 updates.
Another note - it's worth looking at the PBCOre2 updates as some of them make sense for us to adopt. Things like Format Profile etc..
