### PR TITLE
Makezip update

### DIFF
--- a/accession.py
+++ b/accession.py
@@ -161,11 +161,10 @@ def main(args_):
                 accession_number = args.number
         else:
             accession_number = ififuncs.get_accession_number()
-        if args.pbcore:
-            if args.reference:
-                Reference_Number = args.reference.upper()
-            else:
-                Reference_Number = ififuncs.get_reference_number()
+        if args.reference:
+            Reference_Number = args.reference.upper()
+        else:
+            Reference_Number = ififuncs.get_reference_number()
         if args.acquisition_type:        
             acquisition_type = ififuncs.get_acquisition_type(args.acquisition_type)
             print acquisition_type

--- a/batchaccession.py
+++ b/batchaccession.py
@@ -202,6 +202,7 @@ def process_oe_csv(oe_csv_extraction, source_path):
         try:
             dictionary = {}
             dictionary['Object Entry'] = record['OE No.']
+            dictionary['format'] = record['Format']
             dictionary['donation_date'] = record['Date Received']
             dictionary['normalised_oe_number']  = dictionary['Object Entry'][:2].lower() + dictionary['Object Entry'][3:]
             dictionary['source_path'] = os.path.join(source_path, dictionary['normalised_oe_number'])
@@ -303,12 +304,16 @@ def main(args_):
         for package in sorted(to_accession.keys(), key=natural_keys):
             accession_cmd = [
                 package, '-user', user,
-                '-pbcore', '-f',
+                '-f',
                 '-number', to_accession[package][0],
                 '-reference', to_accession[package][1],
                 '-register', register,
                 '-csv', new_csv
             ]
+            for oe_record in oe_dicts:
+                if oe_record['source_path'] == package:
+                    if not oe_record['format'].lower() == 'dcdm':
+                        accession_cmd.append('-pbcore')
             if len(to_accession[package]) == 4:
                 if not to_accession[package][2] == 'n/a':
                     accession_cmd.extend(['-acquisition_type', '13'])

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -111,7 +111,7 @@ def extract_provenance(filename, output_folder, output_uuid):
     '''
     inputxml = "%s/%s_source_mediainfo.xml" % (output_folder, output_uuid)
     inputtracexml = "%s/%s_source_mediatrace.xml" % (output_folder, output_uuid)
-    dfxml = "%s/%s_dfxml.xml" % (output_folder, output_uuid)
+    dfxml = "%s/%s_source_dfxml.xml" % (output_folder, output_uuid)
     print(' - Generating mediainfo xml of input file and saving it in %s' % inputxml)
     make_mediainfo(inputxml, 'mediaxmlinput', filename)
     print(' - Generating mediatrace xml of input file and saving it in %s' % inputtracexml)

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1808,7 +1808,7 @@ def get_technical_metadata(path, new_log_textfile):
                         'EVENT = Metadata extraction - eventDetail=Mediatrace technical metadata extraction via mediainfo, eventOutcome=%s, agentName=%s' % (inputtracexml, mediainfo_version)
                     )
             elif av_file.lower().endswith(
-                    ('.tif', 'tiff', '.doc', '.txt', '.docx', '.pdf', '.jpg', '.jpeg', '.png', '.rtf', '.xml', '.odt', '.cr2', '.epub', '.ppt', '.pptx', '.xls', '.xlsx', '.gif', '.bmp', '.csv' )
+                    ('.tif', 'tiff', '.doc', '.txt', '.docx', '.pdf', '.jpg', '.jpeg', '.png', '.rtf', '.xml', '.odt', '.cr2', '.epub', '.ppt', '.pptx', '.xls', '.xlsx', '.gif', '.bmp', '.csv', '.zip' )
             ):
                 if av_file[0] != '.':
                     if not av_file.lower().endswith(('.txt', '.csv')):

--- a/makezip.py
+++ b/makezip.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+'''
+Zips and verifies all files and folders within your input directory.
+'''
 from zipfile import ZipFile
 import zipfile
 import sys
@@ -8,7 +11,7 @@ import argparse
 import datetime
 
 
-def parse_args():
+def parse_args(args_):
     '''
     Parse command line arguments.
     '''
@@ -17,44 +20,47 @@ def parse_args():
         ' Written by Kieran O\'Leary.'
     )
     parser.add_argument(
-        'input', help='Input directory'
+        '-i', help='Input directory', required=True
     )
     parser.add_argument(
-        'destination', help='Output directory'
+        '-o', help='Output directory', required=True
     )
-    parsed_args = parser.parse_args()
+    parsed_args = parser.parse_args(args_)
     return parsed_args
 
-def main():
-    args = parse_args()
+def main(args_):
+    '''
+    Zips and verifies all files and folders within your input directory.
+    '''
+    args = parse_args(args_)
     pwd = os.getcwd()
-    source = args.input
-    destination = args.destination
-    # destination = sys.argv[2]
+    source = args.i
+    destination = args.o
     start = datetime.datetime.now()
     name = os.path.basename(source) + '.zip'
     full_zip = os.path.join(destination, name)
-    with ZipFile(full_zip, 'w',zipfile.ZIP_STORED, allowZip64 = True) as myzip:
+    with ZipFile(full_zip, 'w', zipfile.ZIP_STORED, allowZip64=True) as myzip:
         os.chdir(source)
-        for root, dirnames, filenames in os.walk(source):
+        for root, _, filenames in os.walk(source):
             for filename in filenames:
                 full_path = os.path.relpath(os.path.join(root, filename))
                 print('zipping %s' % full_path)
                 myzip.write(full_path)
     finish = datetime.datetime.now()
-    print start, finish           
+    print(start, finish)
     os.chdir(pwd)
     start = datetime.datetime.now()
     time.sleep(5)
     with zipfile.ZipFile(full_zip, 'r') as myzip:
-        print 'verifying..'
-        result =  myzip.testzip()
+        print('verifying..')
+        result = myzip.testzip()
         if result is None:
             print('Python has not detected any errors in your zipfile')
         else:
             print('ERROR DETECTED IN %s '% result)
     finish = datetime.datetime.now()
-    # print start, finish           
-    
+    print(start, finish)
+    return result, full_zip
+
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/makezip.py
+++ b/makezip.py
@@ -44,13 +44,13 @@ def create_zip(source, destination, name):
         for root, _, filenames in os.walk(source):
             for filename in filenames:
                 full_path = os.path.relpath(os.path.join(root, filename))
-                print('zipping %s' % full_path)
+                print(' - Zipping %s' % full_path)
                 myzip.write(full_path)
     zip_finish = datetime.datetime.now()
     os.chdir(pwd)
     verify_start = datetime.datetime.now()
     with zipfile.ZipFile(full_zip, 'r') as myzip:
-        print('verifying..')
+        print(' - Verifying the CRC32 checksums within the ZIP file..')
         result = myzip.testzip()
         if result is None:
             print('Python has not detected any errors in your zipfile')

--- a/makezip.py
+++ b/makezip.py
@@ -28,15 +28,13 @@ def parse_args(args_):
     parsed_args = parser.parse_args(args_)
     return parsed_args
 
-def main(args_):
+def create_zip(source, destination):
     '''
-    Zips and verifies all files and folders within your input directory.
+    Creates an uncompressed zipfile for all files in the source directory
+    and stores the zipfile in the destination directory
     '''
-    args = parse_args(args_)
     pwd = os.getcwd()
-    source = args.i
-    destination = args.o
-    start = datetime.datetime.now()
+    zip_start = datetime.datetime.now()
     name = os.path.basename(source) + '.zip'
     full_zip = os.path.join(destination, name)
     with ZipFile(full_zip, 'w', zipfile.ZIP_STORED, allowZip64=True) as myzip:
@@ -46,11 +44,9 @@ def main(args_):
                 full_path = os.path.relpath(os.path.join(root, filename))
                 print('zipping %s' % full_path)
                 myzip.write(full_path)
-    finish = datetime.datetime.now()
-    print(start, finish)
+    zip_finish = datetime.datetime.now()
     os.chdir(pwd)
-    start = datetime.datetime.now()
-    time.sleep(5)
+    verify_start = datetime.datetime.now()
     with zipfile.ZipFile(full_zip, 'r') as myzip:
         print('verifying..')
         result = myzip.testzip()
@@ -58,8 +54,24 @@ def main(args_):
             print('Python has not detected any errors in your zipfile')
         else:
             print('ERROR DETECTED IN %s '% result)
-    finish = datetime.datetime.now()
-    print(start, finish)
+    verify_finish = datetime.datetime.now()
+    total_zip = zip_finish - zip_start
+    total_verify = verify_finish - verify_start
+    print('Zipping duration = %s seconds' % (str(total_zip)))
+    print('Verification duration = %s seconds' % (str(total_verify)))
+    print('Total duration = %s seconds' % (str(total_zip + total_verify)))
+    return result, full_zip
+
+def main(args_):
+    '''
+    Zips and verifies all files and folders within your input directory.
+    '''
+    args = parse_args(args_)
+    print(args)
+    print('makezip.py started')
+    source = args.i
+    destination = args.o
+    result, full_zip = create_zip(source, destination)
     return result, full_zip
 
 if __name__ == '__main__':

--- a/makezip.py
+++ b/makezip.py
@@ -25,17 +25,19 @@ def parse_args(args_):
     parser.add_argument(
         '-o', help='Output directory', required=True
     )
+    parser.add_argument(
+        '-basename', help='Specify a basename for the output file. A basename is a filename without the full path eg output.zip'
+    )
     parsed_args = parser.parse_args(args_)
     return parsed_args
 
-def create_zip(source, destination):
+def create_zip(source, destination, name):
     '''
     Creates an uncompressed zipfile for all files in the source directory
     and stores the zipfile in the destination directory
     '''
     pwd = os.getcwd()
     zip_start = datetime.datetime.now()
-    name = os.path.basename(source) + '.zip'
     full_zip = os.path.join(destination, name)
     with ZipFile(full_zip, 'w', zipfile.ZIP_STORED, allowZip64=True) as myzip:
         os.chdir(source)
@@ -71,7 +73,11 @@ def main(args_):
     print('makezip.py started')
     source = args.i
     destination = args.o
-    result, full_zip = create_zip(source, destination)
+    if args.basename:
+        name = args.basename
+    else:
+        name = os.path.basename(source) + '.zip'
+    result, full_zip = create_zip(source, destination, name)
     return result, full_zip
 
 if __name__ == '__main__':

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -199,15 +199,27 @@ def make_ffv1(
         uuid = ififuncs.create_uuid()
         # ugly hack until i recfactor. this is the zip_path, not ffv1_path
         ffv1_path = os.path.join(output_dirname, uuid + '.zip')
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = packing, status=started, eventType=packing, agentName=makezip.py, eventDetail=Source object to be packed=%s' % os.path.dirname(source_abspath)
+        )
         makezip_judgement = makezip.main([
             '-i', os.path.dirname(source_abspath),
             '-o', output_dirname,
             '-basename', os.path.basename(ffv1_path)
         ])[0]
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, Source object packed into=%s' % ffv1_path
+        )
         if makezip_judgement is None:
             judgement = 'lossless'
         else:
             judgement = makezip_judgement
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=makezip.py, eventDetail=embedded crc32 checksum validation, eventOutcome=%s' % judgement
+        )
     else:
         logfile = os.path.join(
             temp_dir,

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -190,7 +190,7 @@ def make_ffv1(
             log_name_source,
             'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of source'
         )
-        rawcooked_cmd = ['rawcooked', os.path.dirname(source_abspath), '-o', ffv1_path]
+        rawcooked_cmd = ['rawcooked', os.path.dirname(source_abspath), '--check', 'full', '-o', ffv1_path]
         if args.audio:
             rawcooked_cmd.extend([args.audio, '-c:a', 'copy'])
         ffv12dpx = (rawcooked_cmd)

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -27,6 +27,7 @@ import shutil
 import time
 import ififuncs
 import sipcreator
+import makezip
 
 def short_test(images, args):
     '''
@@ -149,10 +150,11 @@ def make_ffv1(
     )
     temp_dir = tempfile.gettempdir()
     ffv1_path = os.path.join(output_dirname, uuid + '.mkv')
-    source_textfile = os.path.join(
-        temp_dir, uuid + '_source.framemd5'
-    )
-    files_to_move.append(source_textfile)
+    if not args.zip:
+        source_textfile = os.path.join(
+            temp_dir, uuid + '_source.framemd5'
+        )
+        files_to_move.append(source_textfile)
     # Just perform framemd5 at this stage
     if args.rawcooked:
         logfile = os.path.join(
@@ -192,6 +194,20 @@ def make_ffv1(
         if args.audio:
             rawcooked_cmd.extend([args.audio, '-c:a', 'copy'])
         ffv12dpx = (rawcooked_cmd)
+        print(ffv12dpx)
+    elif args.zip:
+        uuid = ififuncs.create_uuid()
+        # ugly hack until i recfactor. this is the zip_path, not ffv1_path
+        ffv1_path = os.path.join(output_dirname, uuid + '.zip')
+        makezip_judgement = makezip.main([
+            '-i', os.path.dirname(source_abspath),
+            '-o', output_dirname,
+            '-basename', os.path.basename(ffv1_path)
+        ])[0]
+        if makezip_judgement is None:
+            judgement = 'lossless'
+        else:
+            judgement = makezip_judgement
     else:
         logfile = os.path.join(
             temp_dir,
@@ -217,46 +233,47 @@ def make_ffv1(
             '-f', 'framemd5', source_textfile
         ]
         normalisation_tool = 'FFmpeg'
-    print(ffv12dpx)
-    ififuncs.generate_log(
-        log_name_source,
-        'EVENT = normalisation, status=started, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
-        % normalisation_tool
-    )
-    subprocess.call(ffv12dpx, env=env_dict)
-    ififuncs.generate_log(
-        log_name_source,
-        'EVENT = normalisation, status=finshed, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
-        % normalisation_tool
-    )
-    ffv1_md5 = os.path.join(
-        temp_dir,
-        uuid + '_ffv1.framemd5'
-    )
-    files_to_move.append(ffv1_md5)
-    ififuncs.generate_log(
-        log_name_source,
-        'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image'
-    )
-    ffv1_fmd5_cmd = [
-        'ffmpeg', '-report',
-        '-i', ffv1_path,
-        '-pix_fmt', pix_fmt,
-        '-f', 'framemd5',
-        ffv1_md5
-    ]
-    ffv1_fmd5_logfile = os.path.join(
-        temp_dir, '%s_ffv1_framemd5.log' % uuid
-    )
-    files_to_move.append(ffv1_fmd5_logfile)
-    ffv1_fmd5_logfile = "\'" + ffv1_fmd5_logfile + "\'"
-    ffv1_fmd5_env_dict = ififuncs.set_environment(ffv1_fmd5_logfile)
-    subprocess.call(ffv1_fmd5_cmd, env=ffv1_fmd5_env_dict)
-    judgement = verify_losslessness(source_textfile, ffv1_md5)
-    ififuncs.generate_log(
-        log_name_source,
-        'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image, eventOutcome=%s' % judgement
-    )
+        print(ffv12dpx)
+    if not args.zip:
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = normalisation, status=started, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
+            % normalisation_tool
+        )
+        subprocess.call(ffv12dpx, env=env_dict)
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = normalisation, status=finshed, eventType=Creation, agentName=%s, eventDetail=Image sequence normalised to FFV1 in a Matroska container'
+            % normalisation_tool
+        )
+        ffv1_md5 = os.path.join(
+            temp_dir,
+            uuid + '_ffv1.framemd5'
+        )
+        files_to_move.append(ffv1_md5)
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image'
+        )
+        ffv1_fmd5_cmd = [
+            'ffmpeg', '-report',
+            '-i', ffv1_path,
+            '-pix_fmt', pix_fmt,
+            '-f', 'framemd5',
+            ffv1_md5
+        ]
+        ffv1_fmd5_logfile = os.path.join(
+            temp_dir, '%s_ffv1_framemd5.log' % uuid
+        )
+        files_to_move.append(ffv1_fmd5_logfile)
+        ffv1_fmd5_logfile = "\'" + ffv1_fmd5_logfile + "\'"
+        ffv1_fmd5_env_dict = ififuncs.set_environment(ffv1_fmd5_logfile)
+        subprocess.call(ffv1_fmd5_cmd, env=ffv1_fmd5_env_dict)
+        judgement = verify_losslessness(source_textfile, ffv1_md5)
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=ffmpeg, eventDetail=Frame level checksums of image, eventOutcome=%s' % judgement
+        )
     if not args.sip:
         return judgement
     else:
@@ -341,6 +358,10 @@ def setup():
     parser.add_argument(
         '-rawcooked',
         help='Use RAWcooked for the normalisation to FFV1/Matroska.', action='store_true'
+    )
+    parser.add_argument(
+        '-zip',
+        help='Use makezip.py to generate an uncompressed zip file', action='store_true'
     )
     parser.add_argument(
         '-short_test',

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -406,6 +406,10 @@ def main(args_):
             new_log_textfile,
             'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=makezip.py, eventDetail=embedded crc32 checksum validation, eventOutcome=%s' % judgement
         )
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=makezip.py, eventDetail=embedded crc32 checksum validation, eventOutcome=%s' % judgement
+        )
     else:
         log_names = move_files(inputs, sip_path, args)
     ififuncs.get_technical_metadata(sip_path, new_log_textfile)
@@ -415,6 +419,14 @@ def main(args_):
     if args.sc:
         normalise_objects_manifest(sip_path)
     new_manifest_textfile = consolidate_manifests(sip_path, 'objects', new_log_textfile)
+    if args.zip:
+        ififuncs.generate_log(
+            new_log_textfile, 'EVENT = Message Digest Calculation: status=started, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
+        )
+        ififuncs.manifest_update(new_manifest_textfile, zip_file)
+        ififuncs.generate_log(
+            new_log_textfile, 'EVENT = Message Digest Calculation: status=closed, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
+        )
     consolidate_manifests(sip_path, 'metadata', new_log_textfile)
     ififuncs.hashlib_append(
         logs_dir, new_manifest_textfile,
@@ -426,7 +438,7 @@ def main(args_):
         package_update.main(supplement_cmd)
     if args.zip:
         os.makedirs(supplemental_dir)
-        supplement_cmd = ['-i', [inputxml, inputtracexml, dfxml], '-user', user, '-new_folder', supplemental_dir, os.path.dirname(sip_path)]
+        supplement_cmd = ['-i', [inputxml, inputtracexml, dfxml], '-user', user, '-new_folder', supplemental_dir, os.path.dirname(sip_path), '-copy']
         package_update.main(supplement_cmd)
     if args.sc:
         print('Generating Digital Forensics XML')

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -393,7 +393,7 @@ def main(args_):
             new_log_textfile,
             'EVENT = packing, status=started, eventType=packing, agentName=makezip.py, eventDetail=Source object to be packed=%s' % inputs[0]
         )
-        makezip_judgement, zip_file = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects')])
+        makezip_judgement, zip_file = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects'), '-basename', uuid + '.zip'])
         ififuncs.generate_log(
             new_log_textfile,
             'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, eventDetail=Source object packed into=%s' % inputs[0]

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -389,7 +389,23 @@ def main(args_):
     logs_dir = os.path.join(sip_path, 'logs')
     if args.zip:
         inputxml, inputtracexml, dfxml = ififuncs.generate_mediainfo_xmls(inputs[0], args.o, uuid, new_log_textfile)
-        makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects')])
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = packing, status=started, eventType=packing, agentName=makezip.py, eventDetail=Source object to be packed=%s' % inputs[0]
+        )
+        makezip_judgement = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects')])
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, eventDetail=Source object packed into=%s' % inputs[0]
+        )
+        if makezip_judgement is None:
+            judgement = 'lossless'
+        else:
+            judgement = makezip_judgement
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=makezip.py, eventDetail=embedded crc32 checksum validation, eventOutcome=%s' % judgement
+        )
     else:
         log_names = move_files(inputs, sip_path, args)
     ififuncs.get_technical_metadata(sip_path, new_log_textfile)

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -409,7 +409,7 @@ def main(args_):
         makezip_judgement, zip_file = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects'), '-basename', uuid + '.zip'])
         ififuncs.generate_log(
             new_log_textfile,
-            'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, eventDetail=Source object packed into=%s' % inputs[0]
+            'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, eventDetail=Source object packed into=%s' % zip_file
         )
         if makezip_judgement is None:
             judgement = 'lossless'

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -389,6 +389,19 @@ def main(args_):
     logs_dir = os.path.join(sip_path, 'logs')
     if args.zip:
         inputxml, inputtracexml, dfxml = ififuncs.generate_mediainfo_xmls(inputs[0], args.o, uuid, new_log_textfile)
+        source_manifest = os.path.join(
+            args.i[0],
+            os.path.basename(args.i[0]) + '_manifest-md5.txt'
+        )
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = message digest calculation, status=started, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files within ZIP'
+        )
+        ififuncs.hashlib_manifest(args.i[0], source_manifest, os.path.dirname(args.i[0]))
+        ififuncs.generate_log(
+            new_log_textfile,
+            'EVENT = message digest calculation, status=finished, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files within ZIP'
+        )
         ififuncs.generate_log(
             new_log_textfile,
             'EVENT = packing, status=started, eventType=packing, agentName=makezip.py, eventDetail=Source object to be packed=%s' % inputs[0]
@@ -419,13 +432,14 @@ def main(args_):
     if args.sc:
         normalise_objects_manifest(sip_path)
     new_manifest_textfile = consolidate_manifests(sip_path, 'objects', new_log_textfile)
+
     if args.zip:
         ififuncs.generate_log(
-            new_log_textfile, 'EVENT = Message Digest Calculation: status=started, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
+            new_log_textfile, 'EVENT = Message Digest Calculation, status=started, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
         )
         ififuncs.manifest_update(new_manifest_textfile, zip_file)
         ififuncs.generate_log(
-            new_log_textfile, 'EVENT = Message Digest Calculation: status=closed, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
+            new_log_textfile, 'EVENT = Message Digest Calculation, status=finished, eventType=message digest calculation, eventDetail=%s module=hashlib' % zip_file
         )
     consolidate_manifests(sip_path, 'metadata', new_log_textfile)
     ififuncs.hashlib_append(
@@ -438,7 +452,7 @@ def main(args_):
         package_update.main(supplement_cmd)
     if args.zip:
         os.makedirs(supplemental_dir)
-        supplement_cmd = ['-i', [inputxml, inputtracexml, dfxml], '-user', user, '-new_folder', supplemental_dir, os.path.dirname(sip_path), '-copy']
+        supplement_cmd = ['-i', [inputxml, inputtracexml, dfxml, source_manifest], '-user', user, '-new_folder', supplemental_dir, os.path.dirname(sip_path), '-copy']
         package_update.main(supplement_cmd)
     if args.sc:
         print('Generating Digital Forensics XML')

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -393,7 +393,7 @@ def main(args_):
             new_log_textfile,
             'EVENT = packing, status=started, eventType=packing, agentName=makezip.py, eventDetail=Source object to be packed=%s' % inputs[0]
         )
-        makezip_judgement = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects')])
+        makezip_judgement, zip_file = makezip.main(['-i', inputs[0], '-o', os.path.join(sip_path, 'objects')])
         ififuncs.generate_log(
             new_log_textfile,
             'EVENT = packing, status=finished, eventType=packing, agentName=makezip.py, eventDetail=Source object packed into=%s' % inputs[0]


### PR DESCRIPTION
This is an attempt to make `makezip` less embarrassing.
Changes include:
* ifiscripts-style arguments `-i, -o`
* python3 friendly print-statements.
* general pylint/pep-08 compliance.
* display duration of zipping, validation, total time.
* sets up script so that it can be called via other scripts, particularly sipcreator.

Going forward, I was mulling over whether this script could have extensive logging and folder structure generation, but I think that this is best left to sipcreator or seq2ffv1.py. These scripts can call makezip and then do whatever they want. This script should only make and veryify a zip.
