### PR TITLE
seq2ffv1 - initial attempt at whole-file/complete reversibilty test w…

### DIFF
--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -325,14 +325,22 @@ def make_ffv1(
         )
         ififuncs.generate_log(
             log_name_source,
-            'EVENT = message digest calculation, status=started, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files within ZIP'
+            'EVENT = message digest calculation, status=started, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files'
         )
         ififuncs.hashlib_manifest(args.i, source_manifest, os.path.dirname(args.i))
         ififuncs.generate_log(
             log_name_source,
-            'EVENT = message digest calculation, status=finished, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files within ZIP'
+            'EVENT = message digest calculation, status=finished, eventType=messageDigestCalculation, agentName=hashlib, eventDetail=MD5 checksum of source files'
+        )
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=%s, eventDetail=Full reversibility of %s back to its original form, followed by checksum verification using %s ' % (normalisation_tool, ffv1_path, source_manifest)
         )
         judgement = reversibility_verification(ffv1_path, source_manifest)
+        ififuncs.generate_log(
+            log_name_source,
+            'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=%s, eventDetail=Full reversibilty of %s back to its original form, followed by checksum verification using %s , eventOutcome=%s' % (normalisation_tool, ffv1_path, source_manifest, judgement)
+        )
         supplement_cmd = ['-supplement', inputxml, inputtracexml, dfxml, source_manifest]
         sipcreator_cmd = [
             '-i',

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -69,6 +69,8 @@ def reversibility_verification(ffv1_mkv, source_manifest):
     converted_manifest = os.path.join(temp_dir, '123.md5')
     ififuncs.hashlib_manifest(temp_dir, converted_manifest, temp_dir)
     judgement = ififuncs.diff_textfiles(converted_manifest, source_manifest)
+    print(' - Deleting temp directory %s' % temp_dir)
+    shutil.rmtree(temp_dir)
     return judgement
 def run_loop(args):
     '''

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -103,17 +103,15 @@ def run_loop(args):
         if images == 'none':
             continue
         (ffmpeg_friendly_name,
-         start_number, root_filename, fps) = ififuncs.parse_image_sequence(images)
+         _, root_filename, _) = ififuncs.parse_image_sequence(images)
         short_test(images, args)
         source_abspath = os.path.join(source_directory, ffmpeg_friendly_name)
         judgement = make_ffv1(
-            start_number,
             source_abspath,
             output_dirname,
             args,
             log_name_source,
             user,
-            fps
         )
         if args.sip:
             judgement, sipcreator_log, sipcreator_manifest = judgement
@@ -145,13 +143,11 @@ def verify_losslessness(source_textfile, ffv1_md5):
                         checksum_mismatches.append(1)
     return judgement
 def make_ffv1(
-        start_number,
         source_abspath,
         output_dirname,
         args,
         log_name_source,
         user,
-        fps
     ):
     '''
     This launches the image sequence to FFV1/Matroska process
@@ -161,10 +157,6 @@ def make_ffv1(
     if args.sip:
         object_entry = ififuncs.get_object_entry()
     files_to_move = []
-    pix_fmt = ififuncs.img_seq_pixfmt(
-        start_number,
-        source_abspath
-    )
     temp_dir = tempfile.gettempdir()
     ffv1_path = os.path.join(output_dirname, uuid + '.mkv')
     # Just perform framemd5 at this stage
@@ -244,7 +236,7 @@ def make_ffv1(
         if args.reversibility_dir:
             reversibility_dir = args.reversibility_dir
         else:
-            reversibility_dir  = args.o
+            reversibility_dir = args.o
         judgement = reversibility_verification(ffv1_path, source_manifest, reversibility_dir)
         ififuncs.generate_log(
             log_name_source,
@@ -287,15 +279,6 @@ def make_ffv1(
         os.remove(inputxml)
         return judgement, sipcreator_log, sipcreator_manifest
 
-def make_dfxml(args,new_uuid_path,uuid):
-    '''
-    Adds Digital Forensics XML of the source sequence
-    to the supplemental folder.
-    '''
-    metadata = os.path.join(new_uuid_path, 'metadata')
-    dfxml = os.path.join(metadata, uuid + '_dfxml.xml')
-    makedfxml.main([new_uuid_path, '-n', '-o', dfxml])
-    return dfxml
 
 def setup():
     '''

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -56,14 +56,14 @@ def short_test(images, args):
     ififuncs.hashlib_manifest(restored_dir, restored_manifest, restored_dir)
     ififuncs.diff_textfiles(converted_manifest, restored_manifest)
 
-def reversibility_verification(ffv1_mkv, source_manifest):
+def reversibility_verification(ffv1_mkv, source_manifest, reversibility_dir):
     '''
     Restore the MKV back to DPX, create a checksum, and compare to source DPX
     checksums.
     Return a value of lossy or lossless.
     '''
     temp_uuid = ififuncs.create_uuid()
-    temp_dir = os.path.join(tempfile.gettempdir(), temp_uuid)
+    temp_dir = os.path.join(reversibility_dir, temp_uuid)
     os.makedirs(temp_dir)
     subprocess.call(['rawcooked', ffv1_mkv, '-o', temp_dir])
     converted_manifest = os.path.join(temp_dir, '123.md5')
@@ -241,7 +241,11 @@ def make_ffv1(
             log_name_source,
             'EVENT = losslessness verification, status=started, eventType=messageDigestCalculation, agentName=%s, eventDetail=Full reversibility of %s back to its original form, followed by checksum verification using %s ' % (normalisation_tool, ffv1_path, source_manifest)
         )
-        judgement = reversibility_verification(ffv1_path, source_manifest)
+        if args.reversibility_dir:
+            reversibility_dir = args.reversibility_dir
+        else:
+            reversibility_dir  = args.o
+        judgement = reversibility_verification(ffv1_path, source_manifest, reversibility_dir)
         ififuncs.generate_log(
             log_name_source,
             'EVENT = losslessness verification, status=finished, eventType=messageDigestCalculation, agentName=%s, eventDetail=Full reversibilty of %s back to its original form, followed by checksum verification using %s , eventOutcome=%s' % (normalisation_tool, ffv1_path, source_manifest, judgement)
@@ -320,6 +324,9 @@ def setup():
     parser.add_argument(
         '-audio',
         help='Full path to audio file.')
+    parser.add_argument(
+        '-reversibility_dir',
+        help='This argument requires the full path of the location that you want to use for the reversibility directory. By default, seq2ffv1 will use your output dir for storing the temporary reversibility files.')
     parser.add_argument(
         '-zip',
         help='Use makezip.py to generate an uncompressed zip file', action='store_true'


### PR DESCRIPTION
…hile removing framemd5

Based on great feedback from @jeromemartinez - this PR removes the framemd5 reversibility test and instead it automates the manual RAWcooked reversibility check that we are currently performing.
This also adds a source manifest for the original image sequence.
Left to do:
* Add logging
* remove the commented out sections
* test if the non-rawcooked workflows aren't awfully broken
* more hex-editing and deletion testing
* DELETE THE TEMP FILES!!!
* check if enough free space exists on drive, give user Y/N option to continue.