### PR TITLE
Multiple works within one object

### DIFF
--- a/ififuncs.py
+++ b/ififuncs.py
@@ -958,24 +958,13 @@ def get_accession_number():
 
 def get_reference_number():
     '''
-    Asks user for a Filmographic reference number. A valid number (af1####) must be provided.
+    Asks user for a Filmographic reference number. Due to the variety of reference numbers, validation
+    will be removed for now.
     '''
-    reference_number = False
-    while reference_number is False:
-        reference_number = input(
-            '\n\n**** Please enter the Filmographic reference number of the representation\n\n'
-        )
-        if reference_number[:3] != 'af1':
-            print(' - First two characters must be \'af\' and the last five characters must be five digits')
-            reference_number = False
-        elif len(reference_number[2:]) != 5:
-            reference_number = False
-            print(' - First two characters must be \'af\' and last five characters must be five digits')
-        elif not reference_number[2:].isdigit():
-            reference_number = False
-            print(' - First two characters must be \'af\' and last five characters must be five digits')
-        else:
-            return reference_number.upper()
+    reference_number = input(
+        '\n\n**** Please enter the Filmographic reference number of the representation- if there is more than one work that is represented, seperate them with an ampersand, eg af1234&aa675\n\n'
+    )
+    return reference_number.upper()
 
 def get_contenttitletext(cpl):
     '''

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -366,7 +366,7 @@ def main(args_):
                 metadata_dir = root
             elif os.path.basename(root) == 'logs':
                 logs_dir = root
-        csv_filename = os.path.join(metadata_dir, Accession_Number + '_pbcore.csv')
+        csv_filename = os.path.join(metadata_dir, Accession_Number + '_%s_pbcore.csv' % Reference_Number)
         sipcreator_log = os.path.join(
             logs_dir, instantiationIdentif + '_sip_log.log'
         )


### PR DESCRIPTION
This is the dreaded patch for when there are multiple works represented in a single object, EG 4 episodes on one tape, where there is one descriptive metadata record per episode.
So far, this PR allows accession.py to accept multiple reference numbers on the command line in this form: `-reference af12345+ac432+ab567` etc.

This will then result in the following package (i used different args here but you get the picture):
note the multiple filmographic and pbcore csvs that have the name: REF_accessionNumber_pbcore.csv
```
tree /Users/zlad/Desktop/staging/aaa1645 
/Users/zlad/Desktop/staging/aaa1645
├── a5efe037-004c-4494-a826-8c23c6906132
│   ├── logs
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132.mkv_manifest.md5
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_framemd5.log
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_normalise.log
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_sip_log.log
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_source_dfxml.xml_manifest.md5
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_source_mediainfo.xml_manifest.md5
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_source_mediatrace.xml_manifest.md5
│   │   └── metadata_manifest.md5
│   ├── metadata
│   │   ├── AF1235_filmographic.csv
│   │   ├── AF4567_filmographic.csv
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132.framemd5
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132.mkv_mediainfo.xml
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132.mkv_mediatrace.xml
│   │   ├── a5efe037-004c-4494-a826-8c23c6906132_dfxml.xml
│   │   ├── aaa1645_AF1235_pbcore.csv
│   │   ├── aaa1645_AF4567_pbcore.csv
│   │   ├── bars_v210_pcm24le_stereo_20sec.mov_source.framemd5
│   │   └── supplemental
│   │       ├── a5efe037-004c-4494-a826-8c23c6906132_source_dfxml.xml
│   │       ├── a5efe037-004c-4494-a826-8c23c6906132_source_mediainfo.xml
│   │       └── a5efe037-004c-4494-a826-8c23c6906132_source_mediatrace.xml
│   └── objects
│       └── a5efe037-004c-4494-a826-8c23c6906132.mkv
├── a5efe037-004c-4494-a826-8c23c6906132_manifest-sha512.txt
└── a5efe037-004c-4494-a826-8c23c6906132_manifest.md5
```