### PR TITLE
normalise - adds commands to pick correct PAR and colour metadata for…

### DIFF
--- a/normalise.py
+++ b/normalise.py
@@ -93,6 +93,9 @@ def normalise_process(filename, output_folder):
         # let's stipulate the colour metadata if not present for SD PAL material.
         if not ififuncs.get_colour_metadata(ffprobe_dict):
             ffv1_command += ['-color_primaries', 'bt470bg', '-color_trc', 'bt709', '-colorspace', 'bt470bg' ]
+    elif ififuncs.check_for_blackmagic(filename) is True:
+        print(' - A 720/576  with TFF scan type, clap atom featuring 702 width and a PAR of 1.093 has been detected.')
+        ffv1_command += ['-vf', 'setdar=4/3', '-color_primaries', 'bt470bg', '-color_trc', 'bt709', '-colorspace', 'bt470bg']
     ffv1_command += [
         output,
         '-f', 'framemd5', '-an',  # Create decoded md5 checksums for every frame of the input. -an ignores audio


### PR DESCRIPTION
… blackmagic media express captures
Along with this commit: 
https://github.com/kieranjol/IFIscripts/commit/cd383089a42b2f9144bfbe6e1e9d1557e2a1610a

This will force the aspect ratio of 4:3 via the PAR of 1.067.
The function in ififuncs checks to see if there is a clap atom containing 702 width, 703 height and a PAR of 1.093.
Without the corrections in normalise.py to account for this, you will end up with a Display Aspect Ratio of about 1.37 instead of 1.33. i also specified the correct colour metadata values as well.

I tested this with a file from Blackmagic Media Express and the correct command line was produced, which also thankfully passed the Specialist AV mediaconch policy. 
` '-c:v', 'ffv1', '-g', '1', '-level', '3', '-c:a', 'copy', '-map', '0', '-dn', '-report', '-slicecrc', '1', '-slices', '16', '-vf', 'setdar=4/3', '-color_primaries', 'bt470bg', '-color_trc', 'bt709', '-colorspace', 'bt470bg', `

I also tried with a FCP type file to make sure that `check_for_fcp` still works - and it does.
AAAnd i tried it with a regular old file that does not have any of these fancy pieces of metadata and it proceeded as expected.

So I think this is good to merge.