### PR TITLE
seq2ffv1 - adds -framerate option

### DIFF
--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -208,6 +208,8 @@ def make_ffv1(
     rawcooked_logfile = "\'" + rawcooked_logfile + "\'"
     env_dict = ififuncs.set_environment(rawcooked_logfile)
     rawcooked_cmd = ['rawcooked', reel, '--check', 'full', '-c:a', 'copy', '-o', ffv1_path]
+    if args.framerate:
+        rawcooked_cmd.extend(['-framerate', args.framerate])
     ffv12dpx = (rawcooked_cmd)
     print(ffv12dpx)
     if args.zip:
@@ -354,6 +356,9 @@ def setup():
     parser.add_argument(
         '-reversibility_dir',
         help='This argument requires the full path of the location that you want to use for the reversibility directory. By default, seq2ffv1 will use your output dir for storing the temporary reversibility files.')
+    parser.add_argument(
+        '-framerate',
+        help='This argument triggers the -framerate option in rawcooked and allows you to override the default fps value, eg -framerate 16')
     parser.add_argument(
         '-zip',
         help='Use makezip.py to generate an uncompressed zip file', action='store_true'


### PR DESCRIPTION
As reported by @Yujing199603 - some DPX sequences have the incorrect FPS - which then gets passed along to the MKV file via rawcooked which results in bad framerates for the access copies.

This patch adds a `-framerate` option which will force a different framerate. I tested this with a DPX sequence that had an FPS of 24, but I used `-framerate 16` which resulted in the correct fps being used, and the losslessness verification was still LOSSLESS.

This would appear to make the DPX header modification unnecessary. plz review @raecasey 