### PR TITLE
add support for splitting zips greater than 500 gigs

### DIFF
--- a/makezip.py
+++ b/makezip.py
@@ -10,6 +10,7 @@ import time
 import argparse
 import subprocess
 import datetime
+import ififuncs
 
 
 def parse_args(args_):
@@ -41,7 +42,12 @@ def create_zip(source, destination, name):
     zip_start = datetime.datetime.now()
     full_zip = os.path.join(destination, name)
     os.chdir(os.path.dirname(source))
-    subprocess.call(['7za', 'a', '-tzip', '-mx=0', full_zip, os.path.basename(source)])
+    # check if input folder size is greater than 500 gigs 500000000000
+    if ififuncs.get_folder_size(source) > 500000000000:
+        subprocess.call(['7za', 'a', '-tzip', '-v500g', '-mx=0', full_zip, os.path.basename(source)])
+        full_zip = full_zip + '.001'
+    else:
+        subprocess.call(['7za', 'a', '-tzip', '-mx=0', full_zip, os.path.basename(source)])
     zip_finish = datetime.datetime.now()
     os.chdir(pwd)
     verify_start = datetime.datetime.now()

--- a/makezip.py
+++ b/makezip.py
@@ -51,13 +51,24 @@ def create_zip(source, destination, name):
     zip_finish = datetime.datetime.now()
     os.chdir(pwd)
     verify_start = datetime.datetime.now()
-    with zipfile.ZipFile(full_zip, 'r') as myzip:
-        print(' - Verifying the CRC32 checksums within the ZIP file..')
-        result = myzip.testzip()
-        if result is None:
+    print(' - Verifying the CRC32 checksums within the ZIP file..')
+    if full_zip.endswith('.001'):
+        try:
+            result = subprocess.check_output(['7za', 't', full_zip,], stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            if 'Error' in e.output:
+                result = 'FAILURE - Error Detected'
+                print(e.output)
+                print(result)
+        if 'Everything is Ok' in result:
             print('Python has not detected any errors in your zipfile')
-        else:
-            print('ERROR DETECTED IN %s '% result)
+    else:
+        with zipfile.ZipFile(full_zip, 'r') as myzip:
+            result = myzip.testzip()
+            if result is None:
+                print('Python has not detected any errors in your zipfile')
+            else:
+                print('ERROR DETECTED IN %s '% result)
     verify_finish = datetime.datetime.now()
     total_zip = zip_finish - zip_start
     total_verify = verify_finish - verify_start


### PR DESCRIPTION
This will split up zips that are greater than 500 gigs in size. Merging is blocked because the internal python Zipfile module does not support split zip archives, and we use Zipfile to perform the validation. 
So 7za validation is needed instead.
This requires:
* Parsing the 7za error messages to detect success and failure
* Figuring out if we should just use 7za for all verification. I'd imagine that the potential of multithreading could boost performance in general.

