### PR TITLE
Python3 august2019

### DIFF
--- a/accession.py
+++ b/accession.py
@@ -10,6 +10,7 @@ import sys
 import os
 import argparse
 import time
+import collections
 import csv
 import ififuncs
 import manifest
@@ -130,7 +131,7 @@ def insert_filmographic(filmographic_csv, Reference_Number, package_filmographic
     csv_dict = ififuncs.extract_metadata(filmographic_csv)
     for items in csv_dict:
         for x in items:
-            if type(x) is dict:
+            if type(x) is collections.OrderedDict:
                 if Reference_Number in x['Reference Number'].upper():
                     with open(package_filmographic, 'w') as csvfile:
                         fieldnames = csv_dict[1]

--- a/accession.py
+++ b/accession.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 '''
 Runs (Spectrum) accessioning procedures on packages
 that have been through the Object Entry process

--- a/batchaccession.py
+++ b/batchaccession.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Batch process packages by running accession.py and makepbcore.py
 The outcome will be:

--- a/batchaccession.py
+++ b/batchaccession.py
@@ -109,9 +109,9 @@ def initial_check(args, accession_digits, oe_list, reference_number):
                             reference_digits += 1
                             accession_digits += 1
     for fails in wont_accession:
-        print '%s looks like it is not a fully formed SIP. Perhaps loopline_repackage.py should proccess it?' % fails
+        print('%s looks like it is not a fully formed SIP. Perhaps loopline_repackage.py should proccess it?' % fails)
     for success in sorted(to_accession.keys()):
-        print '%s will be accessioned as %s' %  (success, to_accession[success])
+        print('%s will be accessioned as %s' %  (success, to_accession[success]))
     return to_accession
 
 def get_filmographic_titles(to_accession, filmographic_dict):
@@ -123,7 +123,7 @@ def get_filmographic_titles(to_accession, filmographic_dict):
         oe = oe_number[:2].upper() + '-' + oe_number[2:]
         for record in filmographic_dict:
             if record['Object Entry'] == oe:
-                print record['Title']
+                print(record['Title'])
 def parse_args(args_):
     '''
     Parse command line arguments.
@@ -178,14 +178,14 @@ def get_number(args):
     '''
     if args.start_number:
         if args.start_number[:3] != 'aaa':
-            print 'First three characters must be \'aaa\' and last four characters must be four digits'
+            print('First three characters must be \'aaa\' and last four characters must be four digits')
             accession_number = ififuncs.get_accession_number()
         elif len(args.start_number[3:]) not in range(4, 6):
             accession_number = ififuncs.get_accession_number()
-            print 'First three characters must be \'aaa\' and last four characters must be four digits'
+            print('First three characters must be \'aaa\' and last four characters must be four digits')
         elif not args.start_number[3:].isdigit():
             accession_number = ififuncs.get_accession_number()
-            print 'First three characters must be \'aaa\' and last four characters must be four digits'
+            print('First three characters must be \'aaa\' and last four characters must be four digits')
         else:
             accession_number = args.start_number
     else:
@@ -339,14 +339,14 @@ def main(args_):
                     accession_cmd.extend(['-donor', donor])
                     accession_cmd.extend(['-depositor_reference', depositor_reference])
                     accession_cmd.extend(['-acquisition_type', acquisition_type[2]])
-                    print to_accession[package][3]
+                    print(to_accession[package][3])
                     accession_cmd.extend(['-donation_date', to_accession[package][3]])
-            print accession_cmd
+            print(accession_cmd)
             accession.main(accession_cmd)
     collated_pbcore = gather_metadata(args.input)
     sorted_filepath = ififuncs.sort_csv(register, 'accession number')
-    print '\nA helper accessions register has been generated in order to help with registration - located here: %s' % sorted_filepath
-    print '\nA modified filmographic CSV has been generated with added reference numbers - located here: %s' % new_csv
-    print '\nA collated CSV consisting of each PBCore report has been generated for batch database import - located here: %s' % collated_pbcore
+    print('\nA helper accessions register has been generated in order to help with registration - located here: %s' % sorted_filepath)
+    print('\nA modified filmographic CSV has been generated with added reference numbers - located here: %s' % new_csv)
+    print('\nA collated CSV consisting of each PBCore report has been generated for batch database import - located here: %s' % collated_pbcore)
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/bitc.py
+++ b/bitc.py
@@ -24,7 +24,7 @@ def getffprobe(variable, streamvalue, which_file):
         '-of', 'default=noprint_wrappers=1:nokey=1',
         which_file
     ])
-    return variable
+    return variable.decode(sys.stdout.encoding)
 
 
 def set_options(args_):
@@ -129,7 +129,7 @@ def build_filter(args, filename):
         if filtergraph[-1] == ',':
             filtergraph = filtergraph[:-1]
         filter_list = ['-filter_complex', filtergraph]
-        print filter_list
+        print(filter_list)
     return filter_list
 
 
@@ -156,7 +156,7 @@ def get_filenames(args):
                     video_files.append(os.path.join(cli_input, files))
     # Prints some stuff if input isn't a file or directory.
     else:
-        print "Your input isn't a file or a directory."
+        print("Your input isn't a file or a directory.")
     return video_files
 
 
@@ -261,11 +261,11 @@ def make_h264(filename, args, filter_list):
         for _filter in filter_list:
             ffmpeg_args.append(_filter)
     ffmpeg_args.append(output)
-    print ffmpeg_args
+    print(ffmpeg_args)
     subprocess.call(ffmpeg_args)
     if args.md5:
         manifest = '%s_manifest.md5' % filename
-        print 'Generating md5 sidecar...'
+        print('Generating md5 sidecar...')
         h264_md5 = hashlib_md5(filename)
         with open(manifest, 'wb') as fo:
             fo.write('%s  %s' % (h264_md5, filename))

--- a/bitc.py
+++ b/bitc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Accept options from command line and make access copy.
 Use bitc.py -h for help

--- a/copyit.py
+++ b/copyit.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 '''
 Copy pastes drectories while comparing checksum manifests of src and dst.
 '''

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1663,7 +1663,7 @@ def diff_framemd5s(fmd5, fmd5ffv1):
     checksum_mismatches = []
     with open(fmd5) as f1:
         with open(fmd5ffv1) as f2:
-            for (lineno1, line1), (lineno2, line2) in itertools.izip(
+            for (lineno1, line1), (lineno2, line2) in zip(
                     read_non_comment_lines(f1),
                     read_non_comment_lines(f2)
                     ):

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -199,7 +199,7 @@ def get_mediainfo(var_type, type, filename):
         type,
         filename
     ]
-    var_type = subprocess.check_output(mediainfo_cmd).replace('\n', '').replace('\r', '')
+    var_type = subprocess.check_output(mediainfo_cmd).decode(sys.stdout.encoding).replace('\n', '').replace('\r', '')
     return var_type
 
 

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -104,7 +104,7 @@ def make_mediaconch(full_path, mediaconch_xmlfile):
     ]
     print(' - Mediaconch is analyzing %s' % full_path)
     mediaconch_output = subprocess.check_output(mediaconch_cmd)
-    with open(mediaconch_xmlfile, 'wb') as xmlfile:
+    with open(mediaconch_xmlfile, 'w') as xmlfile:
         xmlfile.write(mediaconch_output)
 
 def extract_provenance(filename, output_folder, output_uuid):
@@ -474,7 +474,7 @@ def make_manifest(manifest_dir, relative_manifest_path, manifest_textfile):
         files_in_manifest = len(manifest_list)
         # http://stackoverflow.com/a/31306961/2188572
         manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-        with open(manifest_textfile, "wb") as fo:
+        with open(manifest_textfile, "w") as fo:
             for i in manifest_list:
                 fo.write(i + '\n')
         return files_in_manifest
@@ -518,7 +518,7 @@ def manifest_file_count(manifest2check):
 
 
 def create_csv(csv_file, *args):
-    f = open(csv_file, 'wb')
+    f = open(csv_file, 'w')
     try:
         writer = csv.writer(f)
         writer.writerow(*args)
@@ -527,7 +527,7 @@ def create_csv(csv_file, *args):
 
 
 def append_csv(csv_file, *args):
-    f = open(csv_file, 'ab')
+    f = open(csv_file, 'a')
     try:
         writer = csv.writer(f)
         writer.writerow(*args)
@@ -1020,7 +1020,7 @@ def manifest_replace(manifest, to_be_replaced, replaced_with):
     '''
     with open(manifest, 'r') as fo:
         original_lines = fo.readlines()
-    with open(manifest, 'wb') as ba:
+    with open(manifest, 'w') as ba:
         for lines in original_lines:
             new_lines = lines.replace(to_be_replaced, replaced_with)
             ba.write(new_lines)
@@ -1047,7 +1047,7 @@ def manifest_update(manifest, path):
     manifest_list = manifest_generator.splitlines()
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest,"wb") as fo:
+    with open(manifest,"w") as fo:
         for i in manifest_list:
             fo.write(i + '\n')
 
@@ -1074,7 +1074,7 @@ def sha512_update(manifest, path):
     manifest_list = manifest_generator.splitlines()
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[130:]))
-    with open(manifest,"wb") as fo:
+    with open(manifest,"w") as fo:
         for i in manifest_list:
             fo.write(i + '\n')
 def check_for_uuid(args):
@@ -1172,7 +1172,7 @@ def checksum_replace(manifest, logname, algorithm):
                 elif algorithm == 'sha512':
                     lines = lines[127:].replace(lines[127:], new_checksum + lines[128:])
             updated_manifest.append(lines)
-    with open(manifest, 'wb') as fo:
+    with open(manifest, 'w') as fo:
         for lines in updated_manifest:
             fo.write(lines)
 
@@ -1261,7 +1261,7 @@ def merge_logs(log_name_source, sipcreator_log, sipcreator_manifest):
         concat_lines = concat_log.readlines()
     with open(sipcreator_log, 'r') as sipcreator_log_object:
         sipcreator_lines = sipcreator_log_object.readlines()
-    with open(sipcreator_log, 'wb') as fo:
+    with open(sipcreator_log, 'w') as fo:
         for lines in concat_lines:
             fo.write(lines)
         for remaining_lines in sipcreator_lines:
@@ -1279,7 +1279,7 @@ def merge_logs_append(log_name_source, sipcreator_log, sipcreator_manifest):
         concat_lines = concat_log.readlines()
     with open(sipcreator_log, 'r') as sipcreator_log_object:
         sipcreator_lines = sipcreator_log_object.readlines()
-    with open(sipcreator_log, 'wb') as fo:
+    with open(sipcreator_log, 'w') as fo:
         for lines in sipcreator_lines:
             fo.write(lines)
         for remaining_lines in concat_lines:
@@ -1329,7 +1329,7 @@ def log_results(manifest, log, parent_dir):
     if os.path.isfile(logfile):
         with open(log, 'r') as fo:
             validate_log = fo.readlines()
-        with open(logfile, 'ab') as ba:
+        with open(logfile, 'a') as ba:
             for lines in validate_log:
                 ba.write(lines)
     with open(manifest, 'r') as manifesto:
@@ -1338,7 +1338,7 @@ def log_results(manifest, log, parent_dir):
             if os.path.basename(logname) in lines:
                 lines = lines[:31].replace(lines[:31], ififuncs.hashlib_md5(logfile)) + lines[32:]
             updated_manifest.append(lines)
-    with open(manifest, 'wb') as fo:
+    with open(manifest, 'w') as fo:
         for lines in updated_manifest:
             fo.write(lines)
 

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -61,8 +61,9 @@ def make_mediainfo(xmlfilename, xmlvariable, inputfilename):
         '--output=OLDXML',
         inputfilename
     ]
-    with open(xmlfilename, "w+") as fo:
-        xmlvariable = subprocess.check_output(mediainfo_cmd)
+    with open(xmlfilename, "w") as fo:
+        # https://stackoverflow.com/a/21486747
+        xmlvariable = subprocess.check_output(mediainfo_cmd).decode(sys.stdout.encoding)
         fo.write(xmlvariable)
 
 def make_exiftool(xmlfilename, inputfilename):
@@ -387,7 +388,7 @@ def hashlib_manifest(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest_textfile, "wb") as fo:
+    with open(manifest_textfile, "w") as fo:
         for i in manifest_list:
             fo.write(i + '\n')
 
@@ -424,7 +425,7 @@ def sha512_manifest(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[130:]))
-    with open(manifest_textfile, "wb") as fo:
+    with open(manifest_textfile, "w") as fo:
         for i in manifest_list:
             fo.write(i + '\n')
 
@@ -460,7 +461,7 @@ def hashlib_append(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest_textfile, "ab") as fo:
+    with open(manifest_textfile, "a") as fo:
         for i in manifest_list:
             fo.write(i + '\n')
 
@@ -489,7 +490,8 @@ def make_mediatrace(tracefilename, xmlvariable, inputfilename):
             '--output=XML',
             inputfilename
         ]
-        xmlvariable = subprocess.check_output(mediatrace_cmd)       #input filename
+        # https://stackoverflow.com/a/21486747
+        xmlvariable = subprocess.check_output(mediatrace_cmd).decode(sys.stdout.encoding)
         fo.write(xmlvariable)
 
 
@@ -800,7 +802,7 @@ def sort_manifest(manifest_textfile):
     '''
     with open(manifest_textfile, "r") as fo:
         manifest_lines = fo.readlines()
-        with open(manifest_textfile,"wb") as ba:
+        with open(manifest_textfile,"w") as ba:
             manifest_list = sorted(manifest_lines, key=lambda x: (x[34:]))
             for i in manifest_list:
                 ba.write(i)
@@ -811,7 +813,7 @@ def concat_textfile(video_files, concat_file):
     a condition is needed elsewhere to ensure concat_file is empty
     '''
     for video in video_files:
-        with open(concat_file, 'ab') as textfile:
+        with open(concat_file, 'a') as textfile:
             textfile.write('file \'%s\'\n' % video)
 
 

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1190,7 +1190,7 @@ def img_seq_pixfmt(start_number, path):
         'stream=pix_fmt',
         '-of', 'default=noprint_wrappers=1:nokey=1'
     ]
-    pix_fmt = subprocess.check_output(ffprobe_cmd).rstrip()
+    pix_fmt = subprocess.check_output(ffprobe_cmd).rstrip().decode(sys.stdout.encoding)
     return pix_fmt
 
 def get_ffmpeg_fmt(path, file_type):
@@ -1212,7 +1212,7 @@ def get_ffmpeg_fmt(path, file_type):
         metadata,
         '-of', 'default=noprint_wrappers=1:nokey=1'
     ]
-    pix_fmt = subprocess.check_output(ffprobe_cmd).rstrip().replace("\n", '|')
+    pix_fmt = subprocess.check_output(ffprobe_cmd).rstrip().decode(sys.stdout.encoding).replace("\n", '|')
     return pix_fmt
 
 def get_number_of_tracks(path):
@@ -1228,7 +1228,7 @@ def get_number_of_tracks(path):
         'stream=codec_type',
         '-of', 'default=noprint_wrappers=1:nokey=1'
     ]
-    type_list = subprocess.check_output(ffprobe_cmd).rstrip().splitlines()
+    type_list = subprocess.check_output(ffprobe_cmd).rstrip().decode(sys.stdout.encoding).splitlines()
     types = {}
     final_count = ''
     for i in type_list:

--- a/makepbcore.py
+++ b/makepbcore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Describe AV objects using PBCore in CSV form.
 Ideas for improvement:

--- a/normalise.py
+++ b/normalise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Performs normalisation to FFV1/Matroska.
 This performs a basic normalisation and does not enforce any folder structure.

--- a/order.py
+++ b/order.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Audits logfiles to determine the parent of a derivative package.
 This script can aid in automating large accessioning procedures that involve

--- a/order.py
+++ b/order.py
@@ -42,12 +42,11 @@ def main(args):
                     if 'not a child' in uuid_search:
                         # Checks if a single AV file is in the objects dir.
                         uuid_dir = os.path.join(os.path.dirname(root))
-                        print root
                         if file_count(os.path.join(uuid_dir, 'objects')) == 1:
-                            print '%s has no parent but this could be because it is a single file' % os.path.basename(os.path.dirname(uuid_dir))
+                            print('%s has no parent but this could be because it is a single file' % os.path.basename(os.path.dirname(uuid_dir)))
                             proceed = ififuncs.ask_yes_no('add %s to accession list?' % os.path.basename(os.path.dirname(uuid_dir)))
                             if proceed == 'Y':
-                                print os.path.basename(os.path.dirname(uuid_dir))
+                                print(os.path.basename(os.path.dirname(uuid_dir)))
                                 return os.path.basename(os.path.dirname(uuid_dir))
                         else:
                             # master
@@ -56,7 +55,7 @@ def main(args):
                         parent = uuid_search.split()[-1]
                         # Commenting this out for now - this just adds the dash really.
                         # print parent[:2].upper() + '-' + parent[2:]
-                        print parent
+                        print(parent)
                         return parent
 
 if __name__ == '__main__':

--- a/prores.py
+++ b/prores.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import subprocess

--- a/prores.py
+++ b/prores.py
@@ -77,7 +77,7 @@ elif os.path.isdir(file_without_path):
 
 # Prints some stuff if input isn't a file or directory.
 else: 
-    print "Your input isn't a file or a directory."
+    print("Your input isn't a file or a directory.")
     
                       
 for filename in video_files:
@@ -114,11 +114,9 @@ for filename in video_files:
         filter_options = '-vf'
         
         if args.yadif:
-            print 'YADIF'
             filter_options += ' yadif'         
               
         if args.scale:
-            print 'scale'
             if number_of_effects > 1:
                 filter_options += (',scale=%s' % width_height)                        
             else:
@@ -128,5 +126,5 @@ for filename in video_files:
         for item in filter_options:
             ffmpeg_args.append(item)    
     ffmpeg_args.append(output)
-    print ffmpeg_args
+    print(ffmpeg_args)
     subprocess.call(ffmpeg_args)

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Usage: seq2ffv1.py source_parent_directory output_directory

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Generates SIPS by calling various microservices and functions.
 

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -99,7 +99,7 @@ def consolidate_logs(lognames, path):
     for log in lognames:
         with open(log, 'r') as fo:
             log_lines = fo.readlines()
-        with open(new_log_textfile, 'ab') as log_object:
+        with open(new_log_textfile, 'a') as log_object:
             for lines in log_lines:
                 log_object.write(lines)
 

--- a/validate.py
+++ b/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Validates md5 or sha512 sidecar checksum manifests.
 '''


### PR DESCRIPTION
Just the key scripts in daily IFI use are updated so far.
Current progress - OSX seems to be working OK, Windows and Ubuntu must also be checked.
Copy-paste of my rolling documentation of the work so far (sorry for bad structuring)

Most testing is geared around replicating the output of python2 versions of the scripts. Checking if checksums are the same (where possible) and if not, looking at file sizes, file counts, text diffs to see similarities and differences.

upgrading to python3
OSX
=======
ES2 - `brew upgrade python from 3.7.2 to 3.7.4`
macmini/telecine -` brew unlink python && brew install python `
```
  /usr/local/Cellar/jasper/2.0.16_1: 186 files, 3.6MB, built in 21 seconds
==> Installing gtksourceview3 dependency: netpbm
==> Cloning https://svn.code.sf.net/p/netpbm/code/stable
==> Checking out 3603
svn: E170013: Unable to connect to a repository at URL 'https://svn.code.sf.net/p/netpbm/code/stable'
svn: E230001: Server SSL certificate verification failed: issuer is not trusted
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "netpbm"
Failure while executing; `svn checkout https://svn.code.sf.net/p/netpbm/code/stable /Users/bla/Library/Caches/Homebrew/netpbm--svn -r 3603` exited with 1. Here's the output:
svn: E170013: Unable to connect to a repository at URL 'https://svn.code.sf.net/p/netpbm/code/stable'
svn: E230001: Server SSL certificate verification failed: issuer is not trusted
```

homebrew will upgrade all dependents so this could take time, it ultimately failed with 


Windows
======

It is best to uninstall python 2, then install python3 64-bit. Try to install for all users which should place the exe in C:\Program Files\python37, and make sure to ask the instller to add python to the environmental path.

There can be regedit issues but in general, this should work fine.

```
  /usr/local/Cellar/jasper/2.0.16_1: 186 files, 3.6MB, built in 21 seconds
==> Installing gtksourceview3 dependency: netpbm
==> Cloning https://svn.code.sf.net/p/netpbm/code/stable
==> Checking out 3603
svn: E170013: Unable to connect to a repository at URL 'https://svn.code.sf.net/p/netpbm/code/stable'
svn: E230001: Server SSL certificate verification failed: issuer is not trusted
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "netpbm"
Failure while executing; `svn checkout https://svn.code.sf.net/p/netpbm/code/stable /Users/bla/Library/Caches/Homebrew/netpbm--svn -r 3603` exited with 1. Here's the output:
svn: E170013: Unable to connect to a repository at URL 'https://svn.code.sf.net/p/netpbm/code/stable'
svn: E230001: Server SSL certificate verification failed: issuer is not trusted

```
On OSX, if python 3 is not already installed, it seems that ` brew unlink python && brew install python`` will do the trick.

Always install: `pip3 install lxml`


copyit tests
============
1. create files with testfiles.py
1. run copyit with the output of testfiles .py with both py2 and py3
1. Both have the same manifest checksum - d23dfb3a7c2a87acc451d5d50643ec6f
1. With -l, same checksum for the manifest.
1. with -move, same checksum.

ES2, macmini, telecine - SUCCESS

sipcreator.py
=============
Fails to run on python 3 due to text file opening methods.
```
1. binary append removed which fixed this
Traceback (most recent call last):
  File "sipcreator.py", line 595, in <module>
    main(sys.argv[1:])
  File "sipcreator.py", line 509, in main
    log_names = move_files(inputs, sip_path, args, user)
  File "sipcreator.py", line 141, in move_files
    consolidate_logs(log_names, sip_path)
  File "sipcreator.py", line 104, in consolidate_logs
    log_object.write(lines)
TypeError: a bytes-like object is required, not 'str'
```
1. More binary stuff removed

-supplement did not work due to issues with package_update - fixed.

tests:
Single video file:
Same file count as python2
Same file sizes as python2
object has same checksum
-supplement works
-zip works

ES2 - success




ififuncs.py
===========
many errors
get_technical_metadata has the following issue

```
Traceback (most recent call last):
  File "sipcreator.py", line 595, in <module>
    main(sys.argv[1:])
  File "sipcreator.py", line 510, in main
    ififuncs.get_technical_metadata(sip_path, new_log_textfile)
  File "/Users/bla/ifigit/ifiscripts/ififuncs.py", line 1868, in get_technical_metadata
    inputxml, 'mediaxmlinput', os.path.join(root, av_file)
  File "/Users/bla/ifigit/ifiscripts/ififuncs.py", line 66, in make_mediainfo
    fo.write(xmlvariable)
```    

The type of the variable is now <class 'bytes'>
but in python2 it is <type 'str'>
It seems that using https://stackoverflow.com/a/21486747 might be the best way forward as it detects the system encoding.


normalise.py
============
Broke due to izip no longer being supported for advanced framemd5 diffing.
Fixed, and noemalise appears to perform the same as py2. 
Additional test on es2 - pause the script and alter the fmd5 SAR so that the itertools diff works. This passed

ES2 SUCCESS

validate.py
===========
already compliant
ES2 success

seq2ffv1.py
===========
already compliant
same as py2 output.
ES2 and telecine success

bitc.py
======
Broke due to ffprobe call returning bytes, not string, fixed along with print calls.

es2 success with -clean and default mode

prores.py
=========
broke due to ififuncs ffprobe calls that returned bytes - fixed
es2 success with default and -hq and -yadif 

makepbcore
==========
Broken due to get_mediainfo error in ififuncs - bytes - fixed
lxml errors regarding unicode.

produces same output as py2 on es2_


accession/batchaccession:
=========================
both broken due to filmographic not extracting. this was becuase previously the csv extraction produced a dict, but now it's an OrderedDict.

test - all seems to be the same except for ordering of audio and video track - no big deal.

tried with reproduction and born digital workflows. all good.
file sizes and file count of packages idential.

Findings - reducing code repetition allows for easier migration and troubleshooting.