### PR TITLE
ififuncs/validate - adds better accent normalistion in manifests and …

### DIFF
--- a/copyit.py
+++ b/copyit.py
@@ -172,7 +172,7 @@ def make_manifest(
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest_textfile, "w") as text:
+    with open(manifest_textfile, "w", encoding='utf-8') as text:
         for i in manifest_list:
             text.write(i + '\n')
     return files_in_manifest

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -300,12 +300,12 @@ def set_environment(logfile):
 
 def generate_log(log, what2log):
     if not os.path.isfile(log):
-        with open(log, "w") as fo:
+        with open(log, "w", encoding='utf-8') as fo:
             fo.write(time.strftime("%Y-%m-%dT%H:%M:%S ")
                      + getpass.getuser()
                      + ' ' + what2log + ' \n')
     else:
-        with open(log, "a") as fo:
+        with open(log, "a", encoding='utf-8') as fo:
             fo.write(time.strftime("%Y-%m-%dT%H:%M:%S ")
                      + getpass.getuser()
                      + ' ' + what2log + ' \n')
@@ -392,7 +392,7 @@ def hashlib_manifest(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest_textfile, "w") as fo:
+    with open(manifest_textfile, "w", encoding='utf-8') as fo:
         for i in manifest_list:
             fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
@@ -429,7 +429,7 @@ def sha512_manifest(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[130:]))
-    with open(manifest_textfile, "w") as fo:
+    with open(manifest_textfile, "w", encoding='utf-8') as fo:
         for i in manifest_list:
             fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
@@ -465,7 +465,7 @@ def hashlib_append(manifest_dir, manifest_textfile, path_to_remove):
     files_in_manifest = len(manifest_list)
     # http://stackoverflow.com/a/31306961/2188572
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-    with open(manifest_textfile, "a") as fo:
+    with open(manifest_textfile, "a", encoding='utf-8') as fo:
         for i in manifest_list:
             fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
@@ -478,7 +478,7 @@ def make_manifest(manifest_dir, relative_manifest_path, manifest_textfile):
         files_in_manifest = len(manifest_list)
         # http://stackoverflow.com/a/31306961/2188572
         manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
-        with open(manifest_textfile, "w") as fo:
+        with open(manifest_textfile, "w", encoding='utf-8') as fo:
             for i in manifest_list:
                 fo.write((unicodedata.normalize('NFC', i) + '\n'))
         return files_in_manifest

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -79,7 +79,7 @@ def make_exiftool(xmlfilename, inputfilename):
         '-j',
         inputfilename
     ]
-    with open(xmlfilename, "w+") as fo:
+    with open(xmlfilename, "w", encoding='utf8') as fo:
         xmlvariable = subprocess.check_output(exiftool_cmd).decode(sys.stdout.encoding)
         fo.write(xmlvariable)
 def make_siegfried(xmlfilename, inputfilename):

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -80,7 +80,15 @@ def make_exiftool(xmlfilename, inputfilename):
         inputfilename
     ]
     with open(xmlfilename, "w", encoding='utf8') as fo:
-        xmlvariable = subprocess.check_output(exiftool_cmd).decode(sys.stdout.encoding)
+        try:
+            xmlvariable = subprocess.check_output(exiftool_cmd).decode(sys.stdout.encoding)
+        # exiftool has difficulties with unicode support on windows.
+        # instead of exiftool reading the file, the file is loading into memory
+        # and exiftool anaylses that instead.
+        # https://exiftool.org/exiftool_pod.html#WINDOWS-UNICODE-FILE-NAMES
+        except subprocess.CalledProcessError:
+            with open(inputfilename, 'rb') as file_object:
+                xmlvariable = subprocess.check_output(['exiftool', '-j', '-'], stdin=file_object).decode("utf-8")
         fo.write(xmlvariable)
 def make_siegfried(xmlfilename, inputfilename):
     '''

--- a/ififuncs.py
+++ b/ififuncs.py
@@ -394,7 +394,7 @@ def hashlib_manifest(manifest_dir, manifest_textfile, path_to_remove):
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
     with open(manifest_textfile, "w") as fo:
         for i in manifest_list:
-            fo.write(i + '\n')
+            fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
 def sha512_manifest(manifest_dir, manifest_textfile, path_to_remove):
     '''
@@ -431,7 +431,7 @@ def sha512_manifest(manifest_dir, manifest_textfile, path_to_remove):
     manifest_list = sorted(manifest_list, key=lambda x: (x[130:]))
     with open(manifest_textfile, "w") as fo:
         for i in manifest_list:
-            fo.write(i + '\n')
+            fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
 def hashlib_append(manifest_dir, manifest_textfile, path_to_remove):
     '''
@@ -467,7 +467,7 @@ def hashlib_append(manifest_dir, manifest_textfile, path_to_remove):
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
     with open(manifest_textfile, "a") as fo:
         for i in manifest_list:
-            fo.write(i + '\n')
+            fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
 
 def make_manifest(manifest_dir, relative_manifest_path, manifest_textfile):
@@ -480,7 +480,7 @@ def make_manifest(manifest_dir, relative_manifest_path, manifest_textfile):
         manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
         with open(manifest_textfile, "w") as fo:
             for i in manifest_list:
-                fo.write(i + '\n')
+                fo.write((unicodedata.normalize('NFC', i) + '\n'))
         return files_in_manifest
     else:
         print(' - Manifest already exists')
@@ -1061,7 +1061,7 @@ def manifest_update(manifest, path):
     manifest_list = sorted(manifest_list, key=lambda x: (x[34:]))
     with open(manifest,"w") as fo:
         for i in manifest_list:
-            fo.write(i + '\n')
+            fo.write((unicodedata.normalize('NFC', i) + '\n'))
 
 def sha512_update(manifest, path):
     '''
@@ -1088,7 +1088,7 @@ def sha512_update(manifest, path):
     manifest_list = sorted(manifest_list, key=lambda x: (x[130:]))
     with open(manifest,"w") as fo:
         for i in manifest_list:
-            fo.write(i + '\n')
+            fo.write((unicodedata.normalize('NFC', i) + '\n'))
 def check_for_uuid(args):
     '''
     Tries to check if a filepath contains a UUID.
@@ -1971,8 +1971,9 @@ def count_stuff(source):
         directories[:] = [d for d in directories if d[0] != '.']
         for files in filenames:
             source_count += 1
-            relative_path = os.path.join(root, files).replace(os.path.dirname(source), '')[1:]
+            relative_path = unicodedata.normalize('NFC', os.path.join(root, files).replace(os.path.dirname(source), ''))[1:]
             file_list.append(relative_path.replace("\\", "/"))
+    print(file_list)
     if os.path.isfile(source):
         if len(file_list) == 0:
             source_count = 1

--- a/validate.py
+++ b/validate.py
@@ -44,7 +44,7 @@ def parse_manifest(manifest, log_name_source):
     paths = []
     proceed = 'Y'
     os.chdir(os.path.dirname(manifest))
-    with open(manifest, 'r') as manifest_object:
+    with open(manifest, 'r', encoding='utf-8') as manifest_object:
         try:
             manifest_list = manifest_object.readlines()
         except UnicodeDecodeError:

--- a/validate.py
+++ b/validate.py
@@ -6,6 +6,7 @@ import sys
 import os
 import argparse
 import time
+import unicodedata
 import ififuncs
 from ififuncs import make_desktop_logs_dir
 
@@ -55,7 +56,9 @@ def parse_manifest(manifest, log_name_source):
                 path = entries[130:].replace('\r', '').replace('\n', '')
             else:
                 path = entries[34:].replace('\r', '').replace('\n', '')
-            path = path.replace('\\', '/')
+            path = unicodedata.normalize('NFC', path).replace('\\', '/')
+            if not os.path.isfile(path):
+                path = unicodedata.normalize('NFD', path)
             if not os.path.isfile(path):
                 ififuncs.generate_log(
                     log_name_source,


### PR DESCRIPTION
…scripts

This uses `unicodedata` to handlke fadas/irish and other non-english accents in filenames.
it will use either NFC or NFD depending on the contxt - NFC for manifests, but NFD for checking if a file exists
https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize