### PR TITLE
Subprocess dependencies

### DIFF
--- a/bitc.py
+++ b/bitc.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import os
 from ififuncs import hashlib_md5
-
+import ififuncs
 
 def getffprobe(variable, streamvalue, which_file):
     '''
@@ -225,6 +225,7 @@ def main(args_):
     '''
     Launch the various functions that will make a h264/mp4 access copy.
     '''
+    ififuncs.check_existence(['ffprobe', 'ffmpeg'])
     args = set_options(args_)
     video_files = get_filenames(args)
     for filename in video_files:

--- a/concat.py
+++ b/concat.py
@@ -127,6 +127,7 @@ def main(args_):
     '''
     Launches the functions that prepare and execute the concatenation.
     '''
+    ififuncs.check_existence(['ffmpeg', 'mkvpropedit', 'mediainfo'])
     uuid = ififuncs.create_uuid()
     args = parse_args(args_)
     print(args)

--- a/dcpaccess.py
+++ b/dcpaccess.py
@@ -62,7 +62,7 @@ if args.bag:
 else:
     bagging = 'disabled'
 '''
-
+ififuncs.check_existence(['ffprobe', 'ffmpeg'])
 if args.m:
     email = 'enabled'
 else:

--- a/dcpfixity.py
+++ b/dcpfixity.py
@@ -26,7 +26,7 @@ try:
     import bagit
 except ImportError:
     print 'skipping error'
-
+ififuncs.check_existence(['ffprobe', 'ffmpeg'])
 parser = argparse.ArgumentParser(description='DCP FIXITY checker/bagging tool.'
                                  ' Written by Kieran O\'Leary.')
 parser.add_argument('input')

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 General
 -------
 
-This is a python 2.7 project. Eventually we will move to python3, but that's for another day (written on 2018-04-08).
+This is a python 3.8 project.
 
 In general, you can just clone or download the whole repository (https://github.com/kieranjol/IFIscripts)  and run the scripts from your cloned path. In the Irish Film Institute, on linux, OSX and Windows, we create a folder in the home directory called ``ifigit``, then we run ``git clone https://github.com/kieranjol/ifiscripts``. Then we add the ``ifiscripts`` folder to ``$PATH`` which allows us to access the scripts from any directory, not just ``ifigit/ifiscripts``. We will be moving to using ``pip`` and ``setup.py`` for installs and updates in the future.
 
@@ -39,7 +39,7 @@ There are some external ``subprocess`` dependencies for most of the scripts. The
 but the following are also needed for many scripts:
 
 * mkvpropedit (installed via mkvtoolnix)
-* siegfried
+* siegfried aka sf
 * exiftool
 * git
 * clairmeta (this requires other dependencies - https://github.com/Ymagis/ClairMeta)
@@ -48,8 +48,12 @@ but the following are also needed for many scripts:
 * rsync
 * gcp (installed via gnu-coreutils on OSX)
 * rawcooked
+* 7zip aka 7za aka p7zip
+* md5deep
+* mediaconch
 
-
-
-
-
+A lot of these can be installed on Ubuntu with a single line:
+sudo apt update && sudo apt install ffmpeg mkvtoolnix exiftool git md5deep p7zip
+In order to add the rest, refer to the installation instructions of the relevant tools.
+For mediaarea tools, it can be easiest to use their own snapshot repository:
+``wget https://mediaarea.net/repo/deb/repo-mediaarea-snapshots_1.0-13_all.deb && sudo dpkg -i repo-mediaarea-snapshots_1.0-13_all.deb && sudo apt update && sudo apt install mediainfo dvrescue qcli rawcooked mediaconch``

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,12 +48,12 @@ but the following are also needed for many scripts:
 * rsync
 * gcp (installed via gnu-coreutils on OSX)
 * rawcooked
-* 7zip aka 7za aka p7zip
+* 7zip aka 7za aka p7zip-full
 * md5deep
 * mediaconch
 
 A lot of these can be installed on Ubuntu with a single line:
-``sudo apt update && sudo apt install python3-pip ffmpeg mkvtoolnix exiftool git md5deep p7zip``
+``sudo apt update && sudo apt install python3-pip ffmpeg mkvtoolnix exiftool git md5deep p7zip-full``
 
 In order to add the rest, refer to the installation instructions of the relevant tools.
 For mediaarea tools, it can be easiest to use their own snapshot repository:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -53,7 +53,9 @@ but the following are also needed for many scripts:
 * mediaconch
 
 A lot of these can be installed on Ubuntu with a single line:
-sudo apt update && sudo apt install ffmpeg mkvtoolnix exiftool git md5deep p7zip
+``sudo apt update && sudo apt install python3-pip ffmpeg mkvtoolnix exiftool git md5deep p7zip``
+
 In order to add the rest, refer to the installation instructions of the relevant tools.
 For mediaarea tools, it can be easiest to use their own snapshot repository:
+
 ``wget https://mediaarea.net/repo/deb/repo-mediaarea-snapshots_1.0-13_all.deb && sudo dpkg -i repo-mediaarea-snapshots_1.0-13_all.deb && sudo apt update && sudo apt install mediainfo dvrescue qcli rawcooked mediaconch``

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Runs mediaconch on FFV1/MKV files.
 The process will validate the files against the FFV1/MKV/PCM standards.
@@ -86,7 +86,7 @@ def setup(full_path, user):
         sip_root, os.path.basename(parent_dir) + '_manifest.md5'
     )
     if not os.path.isfile(manifest):
-        print 'manifest does not exist %s' % manifest
+        print('manifest does not exist %s' % manifest)
         return 'skipping'
     if os.path.isdir(metadata_dir):
         mediaconch_xmlfile_basename = '%s_mediaconch_validation.xml' % filename
@@ -94,10 +94,10 @@ def setup(full_path, user):
             metadata_dir, mediaconch_xmlfile_basename
         )
         if os.path.isfile(mediaconch_xmlfile):
-            print 'mediaconch xml already exists'
+            print('mediaconch xml already exists')
             return 'skipping'
     else:
-        print 'no metadata directory found. Exiting.'
+        print('no metadata directory found. Exiting.')
     return log_name_source, user, mediaconch_xmlfile, manifest, full_path, parent_dir
 
 
@@ -176,12 +176,12 @@ def main():
                         log_name_source, user, mediaconch_xmlfile, manifest, full_path,
                     )
                     validation_outcome = parse_mediaconch(mediaconch_xmlfile)
-                    print str(validation_outcome)
+                    print(str(validation_outcome))
                     if int(validation_outcome['fail_count']) > 0:
-                        print 'Validation failed!'
+                        print('Validation failed!')
                         event_outcome = 'fail'
                     elif int(validation_outcome['fail_count']) == 0:
-                        print 'validation successful'
+                        print('validation successful')
                         event_outcome = 'pass'
                     ififuncs.generate_log(
                         log_name_source,

--- a/ffv1mkvvalidate.py
+++ b/ffv1mkvvalidate.py
@@ -160,6 +160,7 @@ def main():
     '''
     Launches the functions that will validate your FFV1/MKV files.
     '''
+    ififuncs.check_existence(['mediaconch'])
     args = parse_args()
     source = args.input
     user = ififuncs.get_user()

--- a/framemd5.py
+++ b/framemd5.py
@@ -6,6 +6,7 @@ If the input is a file, then framemd5.py will just generate a sidecar for this o
 import subprocess
 import os
 import argparse
+import ififuncs
 
 def parse_args():
     '''
@@ -26,6 +27,7 @@ def main():
     '''
     Simple recursive process that makes framemd5 sidecar reports.
     '''
+    ififuncs.check_existence(['ffmpeg'])
     args = parse_args()
     source = args.i
     fmd5 = source + '_source.framemd5'

--- a/makezip.py
+++ b/makezip.py
@@ -12,7 +12,6 @@ import subprocess
 import datetime
 import ififuncs
 
-
 def parse_args(args_):
     '''
     Parse command line arguments.
@@ -95,4 +94,5 @@ def main(args_):
     return result, full_zip
 
 if __name__ == '__main__':
+    ififuncs.check_existence(['7za'])
     main(sys.argv[1:])

--- a/massqc.py
+++ b/massqc.py
@@ -6,12 +6,14 @@ qcli makes xml.gz QCTools reports.
 import sys
 import subprocess
 import os
+import ififuncs
 
 
 def main():
     '''
     Simple recursive process that makes QCTools sidecar reports.
     '''
+    ififuncs.check_existence(['qcli'])
     source = sys.argv[1]
     if os.path.isfile(source):
         cmd = [

--- a/normalise.py
+++ b/normalise.py
@@ -142,6 +142,7 @@ def verify_losslessness(output_folder, output, output_uuid, fmd5):
     return fmd5_logfile, fmd5ffv1, verdict
 
 def main(args_):
+    ififuncs.check_existence(['ffmpeg', 'mediainfo'])
     print('\n - Normalise.py started')
     args = parse_args(args_)
     print(args)

--- a/prores.py
+++ b/prores.py
@@ -48,6 +48,7 @@ def main(args_):
     '''
     Launch the various functions that will make a h264/mp4 access copy.
     '''
+    ififuncs.check_existence(['ffmpeg'])
     args = set_options(args_)
     prores_options = []
     

--- a/seq2ffv1.py
+++ b/seq2ffv1.py
@@ -374,6 +374,7 @@ def main():
     '''
     Overly long main function that does most of the heavy lifting.
     '''
+    ififuncs.check_existence(['rawcooked', 'ffmpeg'])
     args = setup()
     run_loop(args)
 

--- a/sipcreator.py
+++ b/sipcreator.py
@@ -411,6 +411,11 @@ def main(args_):
     args = parse_args(args_)
     start = datetime.datetime.now()
     inputs = args.i
+    for input in inputs:
+        if ififuncs.check_av_or_doc(input) == 'av':
+            ififuncs.check_existence(['mediainfo'])
+        elif ififuncs.check_av_or_doc(input) == 'doc':
+            ififuncs.check_existence(['sf', 'exiftool'])
     if args.d:
         try:
             import clairmeta
@@ -418,6 +423,8 @@ def main(args_):
         except ImportError:
             print('Exiting as Clairmeta is not installed. If there is a case for not using clairmeta, please let me know and i can make a workaround')
             sys.exit()
+    if args.zip:
+        ififuncs.check_existence(['7za'])
     print(args)
     user = ififuncs.determine_user(args)
     object_entry = get_object_entry(args)

--- a/testfiles.py
+++ b/testfiles.py
@@ -9,6 +9,7 @@ import subprocess
 import os
 import argparse
 import sys
+import ififuncs
 
 def parse_args(args_):
     '''
@@ -34,6 +35,7 @@ def main(args_):
     '''
     Creates three v210/mov tesfiles in a test_files subdirectory
     '''
+    ififuncs.check_existence(['ffmpeg'])
     args = parse_args(args_)
     output_dir = os.path.join(os.path.abspath(args.o), 'test_files')
     ten_bit_dpx_dir = os.path.join(output_dir, 'ten_bit_dpx')


### PR DESCRIPTION
Thanks to @Colm-Connolly for looking through the scripts and finding the dependencies.
This just adds a check to most key scripts where `shutil.which()` runs at the start of a script, and it tells you if an external dependency is installed.
What's been happening up until now is that on a fresh installtion, a job can run for several hours, but it might fail at the very end with a cryptic error that said that exiftool wasn't installed.

Now, the script tells you immediately.
I also added some doc updates. I'm going to wipe by Ubuntu on Windows install and follow the doc updates from scratch and perform some final tests before merging.