### PR TITLE
Manifest transformation and batchvalidations

### DIFF
--- a/batchvalidate.py
+++ b/batchvalidate.py
@@ -1,26 +1,46 @@
 #!/usr/bin/env python3
-import validate
 import sys
 import os
 import subprocess
-source = sys.argv[1]
-results = []
-for root, dirname, filenames in os.walk(source):
-    error_counter = 0
-    for files in filenames:
-        if files.endswith('_manifest.md5'):
-            if  os.path.basename(root) != 'logs':
-                manifest = os.path.join(root, files)
-                print(manifest)
-                if os.path.isfile(manifest):
-                    error_counter = validate.main([manifest])
-                    if error_counter == 0:
-                        results.append([root, 'success'])
-                    else:
-                        results.append([root, 'failure'])
-                    for result in results:
-                        print(result)
-            else:
-                continue
-for result in results:
-    print(result)
+import argparse
+import validate
+
+def parse_args():
+    '''
+    Parse command line arguments
+    '''
+    parser = argparse.ArgumentParser(description='Recursively launch validate.py')
+    parser.add_argument('input', help='full path to manifest file')
+    parser.add_argument('-y', help ='invokes -y option in validate.py, answers Y to manifest issues', action='store_true')
+    parsed_args = parser.parse_args()
+    return parsed_args
+
+def main():
+    args = parse_args()
+    source = args.input
+    results = []
+    for root, dirname, filenames in os.walk(source):
+        error_counter = 0
+        for files in filenames:
+            if files.endswith('_manifest.md5'):
+                if  os.path.basename(root) != 'logs':
+                    manifest = os.path.join(root, files)
+                    print(manifest)
+                    if os.path.isfile(manifest):
+                        if args.y:
+                            error_counter = validate.main([manifest, '-y'])
+                        else:
+                            error_counter = validate.main([manifest])
+                        if error_counter == 0:
+                            results.append([root, 'success'])
+                        else:
+                            results.append([root, 'failure'])
+                        for result in results:
+                            print(result)
+                else:
+                    continue
+    for result in results:
+        print(result)
+
+if __name__ == '__main__':
+    main()

--- a/manifest_normalise.py
+++ b/manifest_normalise.py
@@ -1,0 +1,57 @@
+#/usr/bin/env python3
+'''
+Normalises manifests so that they adhere to ifiscripts manifest.
+This includes removing lines with hashes.
+Removing lines with just whitespace.
+Creating a new sidecar called _modified_manifest.md5
+The goal is to allow batchaccession to run on the new manifests.
+'''
+import argparse
+import os
+import sys
+import logging
+
+logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.DEBUG)
+
+def parse_args():
+    '''
+    Parse command line arguments
+    '''
+    parser = argparse.ArgumentParser(
+        description='Normalises manifests so that batchvalidate can run. '
+        'New sidecar is generated called with _modified_manifest.md5 at end of filename.'
+    )
+    parser.add_argument(
+        'input',
+        help='full path of input directory. All md5 files will be processed'
+    )
+    parsed_args = parser.parse_args()
+    return parsed_args
+
+def main():
+    '''
+    Launches the functions that will normalise your manifests
+    '''
+    args = parse_args()
+    source_dir = args.input
+    if os.path.isdir(source_dir):
+        for root, _, filenames in os.walk(source_dir):
+            for filename in filenames:
+                if filename[0] != '.' and filename.endswith('.md5'):
+                    old_manifest_file = os.path.join(root, filename)
+                    new_manifest_file = old_manifest_file + '_modified_manifest.md5'
+                    # i'm sure there's a better way to detect if the script already ran..
+                    if not '_modified_manifest.md5_modified_manifest.md5' in new_manifest_file:
+                        with open(old_manifest_file, 'r') as old_manifest:
+                            with open(new_manifest_file, 'w') as new_manifest:
+                                for line in old_manifest.readlines():
+                                    if not (line[0] == '#' or line == '\n'):
+                                        logging.info('changing %s' % filename)
+                                        new_manifest.write(line)
+                    else:
+                        logging.info('Modified manifests already exist in %s' % root)
+    else:
+        logging.info('Input must be a directory')
+        sys.exit()
+if __name__ == '__main__':
+    main()

--- a/validate.py
+++ b/validate.py
@@ -24,7 +24,7 @@ def get_input(manifest):
     else:
         return manifest
 
-def parse_manifest(manifest, log_name_source):
+def parse_manifest(manifest, log_name_source, args):
     '''
     Analyses the manifest to see if any files are missing.
     Returns a list of missing files and a dictionary containing checksums
@@ -76,7 +76,8 @@ def parse_manifest(manifest, log_name_source):
         for i in file_list:
             if i not in paths:
                 print((i, 'is present in your source directory but not in the source manifest'))
-        proceed = ififuncs.ask_yes_no('Do you want to proceed regardless?')
+        if not args.y:
+            proceed = ififuncs.ask_yes_no('Do you want to proceed regardless?')
     if proceed == 'N':
         print('Exiting')
         sys.exit()
@@ -157,6 +158,7 @@ def make_parser(args_):
                                      ' Written by Kieran O\'Leary.')
     parser.add_argument('input', help='file path of md5 checksum file')
     parser.add_argument('-update_log', help='updates the package log file with the fixity check information', action='store_true')
+    parser.add_argument('-y', help='answer Y to user input questions regarding manifest issues', action='store_true')
     parsed_args = parser.parse_args(args_)
     return parsed_args
 
@@ -166,7 +168,7 @@ def check_manifest(args, log_name_source):
     Launches other functions.
     '''
     manifest = get_input(args.input)
-    manifest_dict, missing_files_list = parse_manifest(manifest, log_name_source)
+    manifest_dict, missing_files_list = parse_manifest(manifest, log_name_source, args)
     error_counter = validate(manifest_dict, manifest, log_name_source, missing_files_list)
     return manifest, error_counter
 


### PR DESCRIPTION
To be added - docs for new script.

Ok so we get manifests from vendors in a variety of formats and we have to transform them. This PR aims to ease that process by:
* Adding `manifest_normalise.py` to create a normalised version of the manifest
* updates `validate.py` and `batchaccession.py` to override potential errors
* Allows us to easily `batchvalidate` files received from our vendor

Regarding the first point - `manifest_normalise.py` will find all md5 manifests, look through them and remove any lines starting with # or that just contain whitespace - these seem to be frequent culprints when vendors use GUI tools to make manifests. It then saves them as a sidecar to the existing manifest with a `_modified_manifest.md5` suffix.  The original vendor md5 is left intact. The `_manifest.md5` is important as it causes `batchvalidate.py` to pick up on the manifest.

So here's what MV8865.md5 looks like:
```
# MD5 checksums generated by MD5summer (http://www.md5summer.org)
# Generated 11/06/2020 13:29:54

7b694dd10a21441def3d01efe399ab84 *MV8776.dv
```

and here's what manifest_normalise.py creates - a file called MV8775.md5_modified_manifest.md5 which contains this info:
```
7b694dd10a21441def3d01efe399ab84 *MV8776.dv

```

Here's what the output looks like:
```
C:\Users\kiera\ifigit\ifiscripts>manifest_normalise.py  E:\DV_batches\IFI_Batch_10
2020-06-18 09:37:12,349 - changing MV8776.md5
2020-06-18 09:37:12,350 - changing MV8805.md5
2020-06-18 09:37:12,352 - changing MV8806.md5
2020-06-18 09:37:12,353 - changing MV8807.md5
2020-06-18 09:37:12,355 - changing MV8808.md5
2020-06-18 09:37:12,356 - changing MV8809.md5
2020-06-18 09:37:12,358 - changing MV8810.md5
2020-06-18 09:37:12,359 - changing MV8811.md5
2020-06-18 09:37:12,360 - changing MV8905.md5
2020-06-18 09:37:12,361 - changing MV8906.md5
2020-06-18 09:37:12,362 - changing MV8907.md5
2020-06-18 09:37:12,363 - changing MV8908.md5
2020-06-18 09:37:12,365 - changing MV8909.md5
2020-06-18 09:37:12,366 - changing MV8910.md5
2020-06-18 09:37:12,367 - changing MV8985.md5
2020-06-18 09:37:12,368 - changing MV8986.md5
```

Now validate and batchvalidate would throw up errors each time due to the naming of our modified manifest - it mistakingly thinks that there are files missing and it gives you that Y/N prompt to continue. So I added the -y option to override this so you can do a proper batch job.
Here's what batchvalidate - previously only used for LTO fixity checks looks like when using this workflow - it's kinda messy due to the errors and also my generally terrible reporting - but you see the successes and failures:
```
batchvalidate.py -y E:\DV_batches\IFI_Batch_10
E:\DV_batches\IFI_Batch_10\mv8776\MV8776.md5_modified_manifest.md5
Changing directory to C:\Users\kieran.oleary\ifigit\ifiscripts to extract script version`
[]
 - There is mismatch between your file count and the manifest file count
 - checking which files are different
All files present
Validating MV8776.dv
MV8776.dv has validated
All checksums have validated
['E:\\DV_batches\\IFI_Batch_10\\mv8776', 'success']
E:\DV_batches\IFI_Batch_10\MV8805\MV8805.md5_modified_manifest.md5
Changing directory to C:\Users\kieran.oleary\ifigit\ifiscripts to extract script version`
[]
 - There is mismatch between your file count and the manifest file count
 - checking which files are different
All files present
Validating MV8805.m2t
MV8805.m2t has validated
All checksums have validated
['E:\\DV_batches\\IFI_Batch_10\\mv8776', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8805', 'success']
E:\DV_batches\IFI_Batch_10\MV8806\MV8806.md5_modified_manifest.md5
Changing directory to C:\Users\kieran.oleary\ifigit\ifiscripts to extract script version`
[]
 - There is mismatch between your file count and the manifest file count
 - checking which files are different
All files present
Validating MV8806.dv
MV8806.dv has validated
All checksums have validated
['E:\\DV_batches\\IFI_Batch_10\\mv8776', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8805', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8806', 'success']
E:\DV_batches\IFI_Batch_10\MV8807\MV8807.md5_modified_manifest.md5
Changing directory to C:\Users\kieran.oleary\ifigit\ifiscripts to extract script version`
[]
 - There is mismatch between your file count and the manifest file count
 - checking which files are different
All files present
Validating MV8807.m2t
MV8807.m2t has validated
All checksums have validated
['E:\\DV_batches\\IFI_Batch_10\\mv8776', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8805', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8806', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8807', 'success']
E:\DV_batches\IFI_Batch_10\MV8808\MV8808.md5_modified_manifest.md5
Changing directory to C:\Users\kieran.oleary\ifigit\ifiscripts to extract script version`
[]
 - There is mismatch between your file count and the manifest file count
 - checking which files are different
All files present
Validating MV8808.dv
MV8808.dv has validated
All checksums have validated
['E:\\DV_batches\\IFI_Batch_10\\mv8776', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8805', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8806', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8807', 'success']
['E:\\DV_batches\\IFI_Batch_10\\MV8808', 'success']
```