### PR TITLE
adds make_mediaconch.py

### DIFF
--- a/make_mediaconch.py
+++ b/make_mediaconch.py
@@ -53,6 +53,18 @@ def main():
                             logging.info('Generating sidecar - %s' % sidecar)
                     else:
                         logging.info('%s already exists - skipping' % sidecar)
+                    if filename.endswith('.mkv'):
+                        mkv_implementation_overview_cmd = ['mediaconch', full_path]
+                        mkv_implementation_overview = subprocess.check_output(mkv_implementation_overview_cmd)
+                        if 'fail!' in str(mkv_implementation_overview):
+                            logging.info('%s does not validate against the implementation - look at the sidecar XML for more info' % filename)
+                        elif 'pass!' in str(mkv_implementation_overview):
+                            logging.info('%s: Valid implementation' % filename)
+                        mkv_sidecar_output = subprocess.check_output(['mediaconch', '-fx', full_path])
+                        if not os.path.isfile(full_path + '_implementation_report'):
+                            with open(full_path + '_ImplementationReport.xml', 'wb') as fo:
+                                fo.write(mkv_sidecar_output)
+                                logging.info('Generating implementation report sidecar: %s'% full_path + 'ImplementationReport.xml')
 
 if __name__ == '__main__':
     main()

--- a/make_mediaconch.py
+++ b/make_mediaconch.py
@@ -1,0 +1,58 @@
+#/usr/bin/env python
+'''
+Generates Mediaconch xml reports
+Accepts a file extension pattern and a policy input
+Reports of fails are generated to the screen
+Sidecars in XML format generated
+'''
+import argparse
+import os
+import subprocess
+import logging
+
+logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.DEBUG)
+def parse_args():
+    '''
+    Accept command line arguments
+    '''
+    parser = argparse.ArgumentParser(description='Generates Mediaconch xml reports'
+    'Accepts a file extension pattern and a policy input'
+    'Reports of fails are generated to the screen'
+    'Sidecars in XML format generated'
+    )
+    parser.add_argument('input', help='path to parent directory')
+    parser.add_argument('-object_extension_pattern', help='the filename extension that you would like to scan for')
+    parser.add_argument('-policy', help='the full path to the mediaconch XML policy')
+    parsed_args = parser.parse_args()
+    return parsed_args
+
+def main():
+    '''
+    Launches the main functions
+    '''
+    args = parse_args()
+    source_folder = args.input
+    for root, _, filenames in os.walk(source_folder):
+        for filename in filenames:
+            if filename[0] != '.':
+                if filename.endswith(args.object_extension_pattern):
+                    full_path = os.path.join(root, filename)
+                    sidecar = full_path + '_MediaConchReport.xml'
+                    mediaconch_cmd = ['mediaconch', full_path, '-p', args.policy, '-fx']
+                    # Running mediaconch twice is very lazy but it saves on XML parsing.
+                    mediaconch_overview_cmd = ['mediaconch', full_path, '-p', args.policy]
+                    mediaconch_output = subprocess.check_output(mediaconch_cmd)
+                    mediaconch_overview = subprocess.check_output(mediaconch_overview_cmd)
+                    if 'fail!' in str(mediaconch_overview):
+                        logging.info('%s does not validate against the policy - look at the sidecar XML for more info' % filename)
+                    elif 'pass!' in str(mediaconch_overview):
+                        logging.info('%s: No failure detected' % filename)
+                    if not os.path.isfile(sidecar):
+                        with open(sidecar, 'wb') as sidecar_object:
+                            sidecar_object.write(mediaconch_output)
+                            logging.info('Generating sidecar - %s' % sidecar)
+                    else:
+                        logging.info('%s already exists - skipping' % sidecar)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script runs mediaconch with a policy against all files in subdirectories. It will provide a pass/fail report to the terminal, but it will also generate XML sidecars for each video file that detail the report.
You provide your input directory, your policy, as well as a filename extension. This allows you to do the following: 
* Scenario - Vendor provides a drive with mov/m2t and dv files.
* Run make_mediaconch once with the m2t/HDV policy but also specify with the `-object_extension_pattern` option that you only want it to run the policy against m2t files. This prevents a bunch of false errors when it tries to validate DV and mov with the HDV policy.
* You can run makemediaconch multiple times for the different filetypes and policies.
```
positional arguments:
  input                 path to parent directory

optional arguments:
  -h, --help            show this help message and exit
  -object_extension_pattern OBJECT_EXTENSION_PATTERN
                        the filename extension that you would like to scan for
  -policy POLICY        the full path to the mediaconch XML policy
```

Example usage:
```
make_mediaconch.py E:\DV_batches -p C:\Users\kieran.oleary\Documents\HDV_mediaconch_policy.xml -object_extension_pattern m2t
2020-06-24 08:17:38,076 - MV8805.m2t: No failure detected
2020-06-24 08:17:38,077 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8805\MV8805.m2t_MediaConchReport.xml
2020-06-24 08:17:38,748 - MV8807.m2t: No failure detected
2020-06-24 08:17:38,749 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8807\MV8807.m2t_MediaConchReport.xml
2020-06-24 08:17:39,074 - MV8810.m2t: No failure detected
2020-06-24 08:17:39,074 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8810\MV8810.m2t_MediaConchReport.xml
2020-06-24 08:17:39,401 - MV8811.m2t: No failure detected
2020-06-24 08:17:39,417 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8811\MV8811.m2t_MediaConchReport.xml
2020-06-24 08:17:39,751 - MV8906.m2t: No failure detected
2020-06-24 08:17:39,751 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8906\MV8906.m2t_MediaConchReport.xml
2020-06-24 08:17:40,099 - MV8907.m2t: No failure detected
2020-06-24 08:17:40,100 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8907\MV8907.m2t_MediaConchReport.xml
2020-06-24 08:17:40,426 - MV8908.m2t: No failure detected
2020-06-24 08:17:40,427 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8908\MV8908.m2t_MediaConchReport.xml
2020-06-24 08:17:40,743 - MV8910.m2t: No failure detected
2020-06-24 08:17:40,744 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8910\MV8910.m2t_MediaConchReport.xml
2020-06-24 08:17:41,083 - MV8985.m2t: No failure detected
2020-06-24 08:17:41,084 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8985\MV8985.m2t_MediaConchReport.xml
2020-06-24 08:17:41,412 - MV8986.m2t: No failure detected
2020-06-24 08:17:41,412 - Generating sidecar - E:\DV_batches\IFI_Batch_10\MV8986\MV8986.m2t_MediaConchReport.xml
2020-06-24 08:17:41,750 - MV8782.m2t: No failure detected
2020-06-24 08:17:41,750 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8782.m2t_MediaConchReport.xml
2020-06-24 08:17:42,070 - MV8942.m2t: No failure detected
2020-06-24 08:17:42,071 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8942\MV8942.m2t_MediaConchReport.xml
2020-06-24 08:17:42,394 - MV8943.m2t: No failure detected
2020-06-24 08:17:42,396 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8943\MV8943.m2t_MediaConchReport.xml
2020-06-24 08:17:42,735 - MV8944.m2t: No failure detected
2020-06-24 08:17:42,736 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8944\MV8944.m2t_MediaConchReport.xml
2020-06-24 08:17:43,058 - MV8945.m2t: No failure detected
2020-06-24 08:17:43,059 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8945\MV8945.m2t_MediaConchReport.xml
2020-06-24 08:17:43,390 - MV8947.m2t: No failure detected
2020-06-24 08:17:43,391 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8947\MV8947.m2t_MediaConchReport.xml
2020-06-24 08:17:43,728 - MV8948.m2t: No failure detected
2020-06-24 08:17:43,729 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8948\MV8948.m2t_MediaConchReport.xml
2020-06-24 08:17:44,049 - MV8949.m2t: No failure detected
2020-06-24 08:17:44,053 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8949\MV8949.m2t_MediaConchReport.xml
2020-06-24 08:17:44,397 - MV8955.m2t: No failure detected
2020-06-24 08:17:44,398 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8955\MV8955.m2t_MediaConchReport.xml
2020-06-24 08:17:44,728 - MV8956.m2t: No failure detected
2020-06-24 08:17:44,728 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8956\MV8956.m2t_MediaConchReport.xml
2020-06-24 08:17:45,054 - MV8957.m2t: No failure detected
2020-06-24 08:17:45,054 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8957\MV8957.m2t_MediaConchReport.xml
2020-06-24 08:17:45,387 - MV8971.m2t: No failure detected
2020-06-24 08:17:45,387 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV8971\MV8971.m2t_MediaConchReport.xml
2020-06-24 08:17:45,719 - MV9101.m2t: No failure detected
2020-06-24 08:17:45,720 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV9101\MV9101.m2t_MediaConchReport.xml
2020-06-24 08:17:46,036 - MV9109.m2t: No failure detected
2020-06-24 08:17:46,046 - Generating sidecar - E:\DV_batches\IFI_Batch_11\MV9109\MV9109.m2t_MediaConchReport.xml
2020-06-24 08:17:46,384 - MV8782.m2t: No failure detected
2020-06-24 08:17:46,385 - Generating sidecar - E:\DV_batches\IFI_New_Versions_June20\MV8782_V2\MV8782.m2t_MediaConchReport.xml
2020-06-24 08:17:46,757 - MV9025.m2t: No failure detected
2020-06-24 08:17:46,757 - Generating sidecar - E:\DV_batches\IFI_New_Versions_June20\MV9025\MV9025.m2t_MediaConchReport.xml
```
